### PR TITLE
Fix Netlify deploy by moving netlify.toml into public/ directory

### DIFF
--- a/public/netlify.toml
+++ b/public/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  publish = "public"
+  publish = "."
   command = "# no build step"
 
 [[redirects]]


### PR DESCRIPTION
Netlify was resolving publish as base/publish = public/public, which doesn't exist. Moving the config into the base directory and setting publish = "." fixes the path resolution.
