### PR TITLE
Harden server security and add SECURITY.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# WMATA Developer API key
+# Get yours at https://developer.wmata.com/
+WMATA_API_KEY=your_api_key_here

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in NextMetro, please report it responsibly.
+
+**Email:** [nick@nickpoole.dev](mailto:nick@nickpoole.dev)
+
+Please include:
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Any potential impact
+
+I will acknowledge receipt within 48 hours and aim to provide a fix or mitigation within 7 days for confirmed issues.
+
+**Please do not** open a public GitHub issue for security vulnerabilities.
+
+## Security Measures
+
+### API Key Protection
+- The WMATA API key is stored server-side in environment variables and is never exposed to the client.
+- All client requests are proxied through the Express backend.
+
+### HTTP Security Headers
+- [Helmet](https://helmetjs.github.io/) is used to set secure HTTP headers including `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`, and others.
+- A Content Security Policy (CSP) restricts resource loading to trusted origins.
+
+### CORS
+- Cross-Origin Resource Sharing is restricted to the production frontend domain and localhost for development.
+
+### Rate Limiting
+- API endpoints are rate-limited to 60 requests per minute per IP to prevent abuse and protect the upstream WMATA API quota.
+
+### Input Validation
+- All station code parameters are validated against the expected WMATA format (`/^[A-K][0-9]{2}$/`) before being forwarded to the upstream API.
+
+### Transport Security
+- HTTPS is enforced on both the Netlify frontend and Render backend.
+- No mixed content is served.
+
+### Data Privacy
+- NextMetro does not collect, store, or process any personally identifiable information (PII).
+- No user accounts, cookies, or tracking are used.
+- All data displayed is sourced from the public WMATA API.
+
+## Supported Versions
+
+Only the latest deployed version of NextMetro receives security updates.
+
+| Version | Supported |
+| ------- | --------- |
+| 2.x     | Yes       |
+| < 2.0   | No        |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,23 @@
 {
-	"name": "nextmetro-backend",
+	"name": "nextmetro",
 	"version": "2.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "nextmetro-backend",
+			"name": "nextmetro",
 			"version": "2.0.0",
+			"license": "MIT",
 			"dependencies": {
 				"cors": "^2.8.5",
 				"dotenv": "^16.5.0",
 				"express": "^5.1.0",
+				"express-rate-limit": "^8.2.1",
+				"helmet": "^8.1.0",
 				"node-fetch": "^2.7.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/accepts": {
@@ -27,28 +33,34 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-			"integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"license": "MIT",
 			"dependencies": {
 				"bytes": "^3.1.2",
 				"content-type": "^1.0.5",
-				"debug": "^4.4.0",
+				"debug": "^4.4.3",
 				"http-errors": "^2.0.0",
-				"iconv-lite": "^0.6.3",
+				"iconv-lite": "^0.7.0",
 				"on-finished": "^2.4.1",
-				"qs": "^6.14.0",
-				"raw-body": "^3.0.0",
-				"type-is": "^2.0.0"
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
 			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -128,9 +140,10 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -269,6 +282,24 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/express-rate-limit": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+			"integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "10.0.1"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
 		"node_modules/finalhandler": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -377,44 +408,64 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/helmet": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+			"integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/http-errors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
 			"dependencies": {
-				"depd": "2.0.0",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"toidentifier": "1.0.1"
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/http-errors/node_modules/statuses": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-			"engines": {
-				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"node_modules/ip-address": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+			"integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
 		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
@@ -574,9 +625,10 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+			"integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
 			},
@@ -596,17 +648,18 @@
 			}
 		},
 		"node_modules/raw-body": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-			"integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
 			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.6.3",
-				"unpipe": "1.0.0"
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
 			},
 			"engines": {
-				"node": ">= 0.8"
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/router": {
@@ -646,7 +699,8 @@
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
 		},
 		"node_modules/send": {
 			"version": "1.2.0",
@@ -794,6 +848,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -837,19 +892,19 @@
 			}
 		},
 		"body-parser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-			"integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
 			"requires": {
 				"bytes": "^3.1.2",
 				"content-type": "^1.0.5",
-				"debug": "^4.4.0",
+				"debug": "^4.4.3",
 				"http-errors": "^2.0.0",
-				"iconv-lite": "^0.6.3",
+				"iconv-lite": "^0.7.0",
 				"on-finished": "^2.4.1",
-				"qs": "^6.14.0",
-				"raw-body": "^3.0.0",
-				"type-is": "^2.0.0"
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
 			}
 		},
 		"bytes": {
@@ -908,9 +963,9 @@
 			}
 		},
 		"debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"requires": {
 				"ms": "^2.1.3"
 			}
@@ -1007,6 +1062,14 @@
 				"vary": "^1.1.2"
 			}
 		},
+		"express-rate-limit": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+			"integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+			"requires": {
+				"ip-address": "10.0.1"
+			}
+		},
 		"finalhandler": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -1079,29 +1142,27 @@
 				"function-bind": "^1.1.2"
 			}
 		},
+		"helmet": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+			"integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg=="
+		},
 		"http-errors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
 			"requires": {
-				"depd": "2.0.0",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"toidentifier": "1.0.1"
-			},
-			"dependencies": {
-				"statuses": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-					"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-				}
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
 			}
 		},
 		"iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			}
@@ -1110,6 +1171,11 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"ip-address": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+			"integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="
 		},
 		"ipaddr.js": {
 			"version": "1.9.1",
@@ -1213,9 +1279,9 @@
 			}
 		},
 		"qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+			"integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
 			"requires": {
 				"side-channel": "^1.1.0"
 			}
@@ -1226,14 +1292,14 @@
 			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
 		},
 		"raw-body": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-			"integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
 			"requires": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.6.3",
-				"unpipe": "1.0.0"
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
 			}
 		},
 		"router": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
 		"cors": "^2.8.5",
 		"dotenv": "^16.5.0",
 		"express": "^5.1.0",
+		"express-rate-limit": "^8.2.1",
+		"helmet": "^8.1.0",
 		"node-fetch": "^2.7.0"
 	}
 }

--- a/server.js
+++ b/server.js
@@ -23,12 +23,14 @@ app.use(helmet({
       styleSrc: ["'self'", 'https://fonts.googleapis.com'],
       fontSrc: ["'self'", 'https://fonts.gstatic.com'],
       imgSrc: ["'self'", 'data:'],
-      connectSrc: ["'self'", 'https://nextmetro.onrender.com'],
+      connectSrc: ["'self'", 'https://nextmetro.onrender.com', 'https://nextmetro.live'],
     },
   },
 }));
 
 const ALLOWED_ORIGINS = [
+  'https://nextmetro.live',
+  'https://www.nextmetro.live',
   'https://nextmetro.netlify.app',
   'http://localhost:3001',
 ];

--- a/server.js
+++ b/server.js
@@ -3,13 +3,48 @@ const path = require('path');
 const dotenv = require('dotenv');
 const fetch = require('node-fetch');
 const cors = require('cors');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
-app.use(cors());
 app.set('trust proxy', true);
+
+// ==============================
+// Security Middleware
+// ==============================
+app.use(helmet({
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'", 'https://fonts.googleapis.com'],
+      fontSrc: ["'self'", 'https://fonts.gstatic.com'],
+      imgSrc: ["'self'", 'data:'],
+      connectSrc: ["'self'", 'https://nextmetro.onrender.com'],
+    },
+  },
+}));
+
+const ALLOWED_ORIGINS = [
+  'https://nextmetro.netlify.app',
+  'http://localhost:3001',
+];
+app.use(cors({
+  origin: ALLOWED_ORIGINS,
+  methods: ['GET'],
+}));
+
+const apiLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later' },
+});
+app.use('/api/', apiLimiter);
 
 // Serve static frontend files
 app.use(express.static(path.join(__dirname, 'public')));
@@ -18,9 +53,19 @@ const WMATA_API_KEY = process.env.WMATA_API_KEY;
 const WMATA_BASE = 'https://api.wmata.com';
 
 // ==============================
+// Input Validation
+// ==============================
+const STATION_CODE_RE = /^[A-K][0-9]{2}$/;
+
+function isValidStationCode(code) {
+  return STATION_CODE_RE.test(code);
+}
+
+// ==============================
 // In-Memory Cache
 // ==============================
 const cache = {};
+const CACHE_MAX_SIZE = 500;
 
 function getCached(key, ttlMs) {
   const entry = cache[key];
@@ -34,14 +79,36 @@ function setCache(key, data) {
   cache[key] = { data, timestamp: Date.now() };
 }
 
+// Periodically prune expired cache entries
+setInterval(() => {
+  const now = Date.now();
+  const ttls = { incidents: 60000, elevators: 120000, fare: 3600000 };
+  for (const key of Object.keys(cache)) {
+    const prefix = key.split('-')[0];
+    const ttl = ttls[prefix];
+    if (ttl && now - cache[key].timestamp > ttl) {
+      delete cache[key];
+    }
+  }
+  // Hard cap: if cache still exceeds max size, drop oldest entries
+  const keys = Object.keys(cache);
+  if (keys.length > CACHE_MAX_SIZE) {
+    keys
+      .sort((a, b) => cache[a].timestamp - cache[b].timestamp)
+      .slice(0, keys.length - CACHE_MAX_SIZE)
+      .forEach((k) => delete cache[k]);
+  }
+}, 5 * 60 * 1000);
+
 // Helper to fetch from WMATA with error handling
 async function wmataFetch(urlPath) {
   const res = await fetch(`${WMATA_BASE}${urlPath}`, {
     headers: { api_key: WMATA_API_KEY },
   });
   if (!res.ok) {
-    const err = new Error(`WMATA API error: ${res.status}`);
-    err.status = res.status;
+    console.error(`WMATA upstream error: ${res.status} for ${urlPath}`);
+    const err = new Error('Upstream API error');
+    err.status = 502;
     throw err;
   }
   return res.json();
@@ -73,6 +140,9 @@ app.get('/api/stations', async (req, res) => {
 // ==============================
 app.get('/api/station/:code', async (req, res) => {
   const { code } = req.params;
+  if (!isValidStationCode(code)) {
+    return res.status(400).json({ error: 'Invalid station code' });
+  }
   const cacheKey = `station-${code}`;
   const cached = getCached(cacheKey, Infinity);
   if (cached) return res.json(cached);
@@ -94,6 +164,9 @@ app.get('/api/station/:code', async (req, res) => {
 // ==============================
 app.get('/api/predictions/:stationCode', async (req, res) => {
   const { stationCode } = req.params;
+  if (!isValidStationCode(stationCode)) {
+    return res.status(400).json({ error: 'Invalid station code' });
+  }
 
   try {
     const data = await wmataFetch(
@@ -144,6 +217,9 @@ app.get('/api/incidents', async (req, res) => {
 // ==============================
 app.get('/api/elevators/:code', async (req, res) => {
   const { code } = req.params;
+  if (!isValidStationCode(code)) {
+    return res.status(400).json({ error: 'Invalid station code' });
+  }
   const cacheKey = `elevators-${code}`;
   const cached = getCached(cacheKey, 120 * 1000);
   if (cached) return res.json(cached);
@@ -167,6 +243,9 @@ app.get('/api/elevators/:code', async (req, res) => {
 // ==============================
 app.get('/api/fare/:from/:to', async (req, res) => {
   const { from, to } = req.params;
+  if (!isValidStationCode(from) || !isValidStationCode(to)) {
+    return res.status(400).json({ error: 'Invalid station code' });
+  }
   const cacheKey = `fare-${from}-${to}`;
   const cached = getCached(cacheKey, 60 * 60 * 1000);
   if (cached) return res.json(cached);


### PR DESCRIPTION
Summary
Fix known dependency vulnerabilities in body-parser and qs (npm audit fix)
Add helmet for security headers and Content Security Policy
Restrict CORS to nextmetro.live, nextmetro.netlify.app, and localhost
Add express-rate-limit (60 req/min per IP) on all API routes
Validate station code params against /^[A-K][0-9]{2}$/ server-side
Add periodic cache cleanup with 500-entry hard cap
Sanitize error responses to avoid leaking upstream WMATA status codes
Add SECURITY.md with vulnerability disclosure policy
Add .env.example for developer onboarding
Test plan
 Verify app loads and fetches predictions normally
 Confirm invalid station codes (e.g. /api/station/ZZZ) return 400
 Check response headers include helmet defaults (X-Content-Type-Options, CSP, etc.)
 Verify CORS rejects requests from unauthorized origins
 Confirm rate limiting kicks in after 60 requests/min