### PR TITLE
Fix API connectivity: use relative URLs and suppress rate-limit validation

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3,7 +3,7 @@
 // Typography: Rajdhani | Theme: Neutral Brutalist
 // ==============================
 
-const API_BASE_URL = 'https://nextmetro.onrender.com';
+const API_BASE_URL = '';
 
 // ---- Station Data ----
 const stations = {

--- a/server.js
+++ b/server.js
@@ -45,6 +45,7 @@ const apiLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later' },
+  validate: { trustProxy: false },
 });
 app.use('/api/', apiLimiter);
 


### PR DESCRIPTION
The frontend was hardcoded to fetch from https://nextmetro.onrender.com which is running stale code missing most API routes (fare, incidents, stations, elevators all return 404). Changed API_BASE_URL to '' so the frontend uses relative URLs against the same Express server that serves the page.

Also added validate: { trustProxy: false } to express-rate-limit config to prevent the ValidationError thrown on every first API request when trust proxy is set to true (breaking change in express-rate-limit v8).
