### PR TITLE
Add retry logic and health checks for Render free-tier cold starts

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -5,6 +5,17 @@
 
 const API_BASE_URL = '';
 
+// ---- Fetch with retry (handles Render free-tier cold starts) ----
+async function fetchWithRetry(url, retries = 2, delayMs = 3000) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const res = await fetch(url);
+    if (res.ok) return res;
+    // Retry on 503 (Render waking up) but not other errors
+    if (res.status !== 503 || attempt === retries) return res;
+    await new Promise((r) => setTimeout(r, delayMs * (attempt + 1)));
+  }
+}
+
 // ---- Station Data ----
 const stations = {
   A01: 'Metro Center',
@@ -278,7 +289,7 @@ async function fetchStationAddress(stationCode) {
   }
   heroStationAddress.textContent = '';
   try {
-    const res = await fetch(API_BASE_URL + '/api/station/' + stationCode);
+    const res = await fetchWithRetry(API_BASE_URL + '/api/station/' + stationCode);
     const data = await res.json();
     if (data && data.Address) {
       const addr = data.Address;
@@ -416,7 +427,7 @@ function parseAffectedLines(linesStr) {
 // ==============================
 async function fetchIncidents() {
   try {
-    const res = await fetch(API_BASE_URL + '/api/incidents');
+    const res = await fetchWithRetry(API_BASE_URL + '/api/incidents');
     if (!res.ok) throw new Error('Incidents API error');
     const data = await res.json();
     currentIncidents = data.Incidents || [];
@@ -543,7 +554,7 @@ async function fetchFacilities(stationCode) {
     const allIncidents = [];
 
     for (const code of codes) {
-      const res = await fetch(API_BASE_URL + '/api/elevators/' + code);
+      const res = await fetchWithRetry(API_BASE_URL + '/api/elevators/' + code);
       if (!res.ok) throw new Error('Elevators API error');
       const data = await res.json();
       if (data.ElevatorIncidents) {
@@ -645,7 +656,7 @@ fareDestination.addEventListener('change', async () => {
   }
 
   try {
-    const res = await fetch(
+    const res = await fetchWithRetry(
       API_BASE_URL + '/api/fare/' + selectedStation + '/' + toCode
     );
     if (!res.ok) throw new Error('Fare API error');
@@ -921,7 +932,7 @@ async function fetchTrains(stationCode) {
 
   try {
     const codes = getPredictionCodes(stationCode);
-    const res = await fetch(API_BASE_URL + '/api/predictions/' + codes);
+    const res = await fetchWithRetry(API_BASE_URL + '/api/predictions/' + codes);
     if (!res.ok) throw new Error('API error');
 
     const data = await res.json();
@@ -1022,7 +1033,7 @@ refreshBtn.addEventListener('click', () => {
   }
 });
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   // Init hero display
   updateHeroDisplay(selectedStation);
 
@@ -1041,6 +1052,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Render system status immediately (all lines Normal) before API returns
   renderSystemStatus([]);
+
+  // Wake up Render backend (free tier sleeps after 15 min of inactivity)
+  try {
+    await fetchWithRetry(API_BASE_URL + '/healthz', 3, 2000);
+  } catch (e) {
+    // Backend may be down — fetches below will handle gracefully
+  }
 
   // Initial data fetches
   fetchTrains(selectedStation);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -617,8 +617,8 @@ function populateFareDestinations() {
   const opts = [];
 
   Object.entries(stations).forEach(([code, name]) => {
-    // Skip the partner codes (C01, F01, F03, E06) to avoid duplicates
-    if (['C01', 'F01', 'F03', 'E06'].includes(code)) return;
+    // Skip multi-platform partner codes and duplicate S-prefix station codes
+    if (['C01', 'F01', 'F03', 'E06', 'S04', 'S09', 'S10', 'S12', 'S13', 'S14'].includes(code)) return;
     if (seen.has(name)) return;
     seen.add(name);
     opts.push({ code, name });

--- a/public/netlify.toml
+++ b/public/netlify.toml
@@ -3,6 +3,12 @@
   command = "# no build step"
 
 [[redirects]]
+  from = "/healthz"
+  to = "https://nextmetro.onrender.com/healthz"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/api/*"
   to = "https://nextmetro.onrender.com/api/:splat"
   status = 200

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,15 @@
+services:
+  - type: web
+    runtime: node
+    name: nextmetro
+    repo: https://github.com/nick-poole/nextmetro.git
+    branch: main
+    plan: free
+    buildCommand: npm install
+    startCommand: node server.js
+    healthCheckPath: /api/stations
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: WMATA_API_KEY
+        sync: false

--- a/server.js
+++ b/server.js
@@ -55,6 +55,21 @@ app.use(express.static(path.join(__dirname, 'public')));
 const WMATA_API_KEY = process.env.WMATA_API_KEY;
 const WMATA_BASE = 'https://api.wmata.com';
 
+if (!WMATA_API_KEY) {
+  console.warn('WARNING: WMATA_API_KEY is not set. All WMATA API calls will fail.');
+}
+
+// ==============================
+// Health Check
+// ==============================
+app.get('/healthz', (req, res) => {
+  res.json({
+    status: 'ok',
+    wmataKeySet: !!WMATA_API_KEY,
+    uptime: process.uptime(),
+  });
+});
+
 // ==============================
 // Input Validation
 // ==============================
@@ -281,4 +296,6 @@ app.use((req, res) => {
 // ==============================
 app.listen(PORT, () => {
   console.log(`Express server listening on port ${PORT}`);
+  console.log(`WMATA API key: ${WMATA_API_KEY ? 'configured' : 'MISSING'}`);
+  console.log(`Node.js ${process.version}`);
 });


### PR DESCRIPTION
## Summary
This PR adds resilience to API calls to handle Render's free-tier cold starts, which can cause 503 Service Unavailable responses. It also adds deployment configuration and improved server diagnostics.

## Key Changes

**Frontend (public/js/app.js):**
- Added `fetchWithRetry()` function that retries failed requests on 503 status with exponential backoff (default 2 retries, 3s delay)
- Updated all API calls to use `fetchWithRetry()` instead of direct `fetch()`:
  - Station address lookups
  - Incidents API
  - Elevators/facilities API
  - Fare calculations
  - Train predictions
- Added backend wake-up call on page load via `/healthz` endpoint to proactively warm up the Render instance
- Made DOMContentLoaded handler async to support the health check
- Expanded fare destination filtering to exclude additional S-prefix duplicate station codes (S04, S09, S10, S12, S13, S14)

**Backend (server.js):**
- Added `/healthz` health check endpoint that returns status, WMATA key configuration, and uptime
- Added warning log if WMATA_API_KEY environment variable is not set
- Enhanced startup logging to show API key status and Node.js version

**Deployment Configuration:**
- Added `render.yaml` for Render deployment with free-tier configuration
- Updated `netlify.toml` to redirect `/healthz` requests to the Render backend

## Implementation Details
- Retry logic only retries on 503 (service unavailable) to avoid retrying permanent errors
- Exponential backoff prevents overwhelming the backend during recovery: `delayMs * (attempt + 1)`
- Health check uses 3 retries with 2s delay to give backend time to wake up on cold start
- All other API calls use 2 retries with 3s delay for user-facing operations

https://claude.ai/code/session_01YLEc4b4cnbvrstFACREQHA