### PR TITLE
Add elevator & escalator status page at /elevators/

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NextMetro displays live train arrivals, system status, service alerts, station f
 - **System Status Ticker** — Scrolling ticker bar showing real-time status for all six Metro lines (Red, Blue, Orange, Green, Yellow, Silver).
 - **System Status Sidebar** — Per-line status with Normal, Delays, and Advisory states derived from live incident data.
 - **Service Alerts Page** — Dedicated [alerts page](https://nextmetro.live/alerts/) showing all WMATA rail incidents (delays, closures, single tracking, advisories) and elevator/escalator outages system-wide. Severity-sorted, auto-refreshing every 30 seconds, with an 8-question FAQ section covering single tracking, delay causes, station closures, and Metro station depths. Schema.org FAQPage structured data for SEO.
-- **Elevator & Escalator Status** — Facility outage tracking with operational/outage counts and detailed descriptions.
+- **Elevator & Escalator Status Page** — Dedicated [elevator & escalator page](https://nextmetro.live/elevators/) with station-grouped outage view, type filters (elevators/escalators), line filters, color-coded accessibility status (green = all working, yellow = escalator out, red = elevator out), summary bar, and 6-question FAQ with FAQPage structured data. Crawlable station names for long-tail SEO. Also shown per-station on the main arrivals page.
 - **Fare Calculator** — Interactive fare lookup between any two stations showing peak, off-peak, and senior/disabled pricing with estimated travel time.
 - **Line Pages** — Dedicated pages for each Metro line with real-time arrivals, station lists with transfer/parking badges, service hours, frequency info, and an FAQ section with structured data for SEO. Currently live: [Red Line](https://nextmetro.live/lines/red/).
 
@@ -67,16 +67,19 @@ nextmetro/
     ├── netlify.toml       Netlify deploy config + API proxy redirects
     ├── alerts/
     │   └── index.html     Service alerts page (rail + elevator/escalator, FAQ)
+    ├── elevators/
+    │   └── index.html     Elevator & escalator status page (station-grouped, filtered)
     ├── fares/
     │   └── index.html     Fare calculator page
     ├── lines/
     │   └── red/
     │       └── index.html Red Line page (stations, service info, FAQ)
     ├── css/
-    │   └── styles.css     Full design system (~3,135 lines)
+    │   └── styles.css     Full design system (~4,060 lines)
     ├── js/
     │   ├── app.js         Application logic (~1,070 lines)
     │   ├── alerts.js      Alerts page — fetches rail + elevator incidents (~360 lines)
+    │   ├── elevators.js   Elevator/escalator page — station-grouped, filtered (~420 lines)
     │   ├── nav.js         Shared navigation bar component (~30 lines)
     │   ├── line.js        Line page logic — arrivals, alerts, FAQ toggle (~355 lines)
     │   └── fares.js       Fare calculator logic (~410 lines)
@@ -150,6 +153,19 @@ The visual design — **Concrete Vault** — is based on the architectural ident
 ---
 
 ## Changelog
+
+### v2.3.0 — Elevator & Escalator Status Page
+
+- Add dedicated elevator/escalator status page at `/elevators/` with real-time outage tracking
+- Station-grouped view: outages organized by station instead of a flat list
+- Dual filter system: filter by unit type (All / Elevators / Escalators) and by Metro line
+- Color-coded accessibility status: red = elevator out (accessibility critical), yellow = escalator out
+- Summary bar showing total outages, elevator/escalator split, and stations affected
+- Accessibility-first sorting: stations with elevator outages always surface to the top
+- SEO: FAQPage schema (6 questions), dynamic meta description, crawlable station names for long-tail "[station] elevator" queries
+- WCAG compliance: `aria-pressed` on filter chips, `role="list"` on station container
+- Site-wide nav updated: Elevators link replaces Map across all pages (desktop + mobile)
+- Sitemap updated with priority 0.9 and `changefreq=always`
 
 ### v2.2.0 — Service Alerts Page
 

--- a/public/404.html
+++ b/public/404.html
@@ -19,7 +19,7 @@
       </a>
       <div class="navbar-links">
         <a href="/alerts/" class="nav-link">Alerts</a>
-        <a href="/map/" class="nav-link">Map</a>
+        <a href="/elevators/" class="nav-link">Elevators</a>
         <a href="/fares/" class="nav-link">Fares</a>
       </div>
       <button class="navbar-toggle" id="navbar-toggle" aria-label="Toggle menu" aria-expanded="false">
@@ -33,7 +33,7 @@
   <!-- Mobile Menu -->
   <div class="mobile-menu" id="mobile-menu">
     <a href="/alerts/" class="mobile-menu-link">Alerts</a>
-    <a href="/map/" class="mobile-menu-link">Map</a>
+    <a href="/elevators/" class="mobile-menu-link">Elevators</a>
     <a href="/fares/" class="mobile-menu-link">Fares</a>
   </div>
 

--- a/public/about.html
+++ b/public/about.html
@@ -21,7 +21,7 @@
       </a>
       <div class="navbar-links">
         <a href="/alerts/" class="nav-link">Alerts</a>
-        <a href="/map/" class="nav-link">Map</a>
+        <a href="/elevators/" class="nav-link">Elevators</a>
         <a href="/fares/" class="nav-link">Fares</a>
       </div>
       <button class="navbar-toggle" id="navbar-toggle" aria-label="Toggle menu" aria-expanded="false">
@@ -35,7 +35,7 @@
   <!-- Mobile Menu -->
   <div class="mobile-menu" id="mobile-menu">
     <a href="/alerts/" class="mobile-menu-link">Alerts</a>
-    <a href="/map/" class="mobile-menu-link">Map</a>
+    <a href="/elevators/" class="mobile-menu-link">Elevators</a>
     <a href="/fares/" class="mobile-menu-link">Fares</a>
   </div>
 

--- a/public/alerts/index.html
+++ b/public/alerts/index.html
@@ -132,7 +132,7 @@
       </a>
       <div class="navbar-links">
         <a href="/alerts/" class="nav-link nav-link--active">Alerts</a>
-        <a href="/map/" class="nav-link">Map</a>
+        <a href="/elevators/" class="nav-link">Elevators</a>
         <a href="/fares/" class="nav-link">Fares</a>
       </div>
       <button class="navbar-toggle" id="navbar-toggle" aria-label="Toggle menu" aria-expanded="false">
@@ -146,7 +146,7 @@
   <!-- Mobile Menu -->
   <div class="mobile-menu" id="mobile-menu">
     <a href="/alerts/" class="mobile-menu-link mobile-menu-link--active">Alerts</a>
-    <a href="/map/" class="mobile-menu-link">Map</a>
+    <a href="/elevators/" class="mobile-menu-link">Elevators</a>
     <a href="/fares/" class="mobile-menu-link">Fares</a>
   </div>
 

--- a/public/crisis/index.html
+++ b/public/crisis/index.html
@@ -21,7 +21,7 @@
       </a>
       <div class="navbar-links">
         <a href="/alerts/" class="nav-link">Alerts</a>
-        <a href="/map/" class="nav-link">Map</a>
+        <a href="/elevators/" class="nav-link">Elevators</a>
         <a href="/fares/" class="nav-link">Fares</a>
       </div>
       <button class="navbar-toggle" id="navbar-toggle" aria-label="Toggle menu" aria-expanded="false">
@@ -35,7 +35,7 @@
   <!-- Mobile Menu -->
   <div class="mobile-menu" id="mobile-menu">
     <a href="/alerts/" class="mobile-menu-link">Alerts</a>
-    <a href="/map/" class="mobile-menu-link">Map</a>
+    <a href="/elevators/" class="mobile-menu-link">Elevators</a>
     <a href="/fares/" class="mobile-menu-link">Fares</a>
   </div>
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -3659,3 +3659,402 @@ a:hover {
     padding: 0.5rem 1rem;
   }
 }
+
+/* ==============================
+   Elevator & Escalator Status Page
+   ============================== */
+.elev-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: var(--nm-space-xl) var(--nm-space-lg);
+}
+
+.elev-page-inner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--nm-space-lg);
+}
+
+/* ---- Type Filter Chips ---- */
+.elev-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--nm-space-xs);
+}
+
+.elev-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  min-height: 44px;
+  background-color: var(--nm-surface);
+  border: 1px solid var(--nm-border);
+  cursor: pointer;
+  transition: background-color var(--nm-transition-fast), border-color var(--nm-transition-fast);
+  user-select: none;
+  -webkit-user-select: none;
+  font-family: var(--nm-font);
+  color: var(--nm-text-secondary);
+}
+
+.elev-filter-chip:hover {
+  background-color: var(--nm-surface-elevated);
+  border-color: var(--nm-border-strong);
+}
+
+.elev-filter-chip--active {
+  background-color: var(--nm-surface-elevated);
+  border-color: var(--nm-amber);
+  color: var(--nm-text-primary);
+}
+
+.elev-filter-chip svg {
+  flex-shrink: 0;
+}
+
+.elev-filter-label {
+  font-family: var(--nm-font);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+/* ---- Line Filter Chips ---- */
+.elev-line-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--nm-space-xs);
+}
+
+.elev-line-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  min-height: 44px;
+  background-color: var(--nm-surface);
+  border: 1px solid var(--nm-border);
+  cursor: pointer;
+  transition: background-color var(--nm-transition-fast), border-color var(--nm-transition-fast);
+  user-select: none;
+  -webkit-user-select: none;
+  font-family: var(--nm-font);
+  color: var(--nm-text-secondary);
+}
+
+.elev-line-chip:hover {
+  background-color: var(--nm-surface-elevated);
+  border-color: var(--nm-border-strong);
+}
+
+.elev-line-chip--active {
+  background-color: var(--nm-surface-elevated);
+  border-color: var(--nm-amber);
+  color: var(--nm-text-primary);
+}
+
+.elev-line-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50% !important;
+  flex-shrink: 0;
+}
+
+/* ---- Summary Bar ---- */
+.elev-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0;
+  background-color: var(--nm-surface);
+  border: 1px solid var(--nm-border);
+  overflow: hidden;
+}
+
+.elev-summary-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--nm-space-md) var(--nm-space-lg);
+  flex: 1 1 auto;
+  min-width: 120px;
+  border-right: 1px solid var(--nm-border-subtle);
+  text-align: center;
+}
+
+.elev-summary-item:last-child {
+  border-right: none;
+}
+
+.elev-summary-item--ok {
+  border-left: 4px solid var(--nm-status-ok);
+}
+
+.elev-summary-value {
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: 1.75rem;
+  color: var(--nm-text-primary);
+  line-height: 1;
+}
+
+.elev-summary-value--ok {
+  color: var(--nm-status-ok);
+  font-size: 1.1rem;
+}
+
+.elev-summary-label {
+  font-family: var(--nm-font);
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: var(--nm-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-top: 4px;
+}
+
+/* ---- Station Cards ---- */
+.elev-stations {
+  display: flex;
+  flex-direction: column;
+  gap: var(--nm-space-md);
+}
+
+.elev-station-card {
+  background-color: var(--nm-surface);
+  border: 1px solid var(--nm-border);
+  overflow: hidden;
+}
+
+.elev-station-card.elev-station--elevator-out {
+  border-left: 4px solid var(--nm-status-error);
+}
+
+.elev-station-card.elev-station--escalator-out {
+  border-left: 4px solid var(--nm-status-warn);
+}
+
+/* Station Header */
+.elev-station-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--nm-space-md);
+  padding: 0.75rem 1.25rem;
+  background-color: var(--nm-surface-elevated);
+  border-bottom: 1px solid var(--nm-border);
+}
+
+.elev-station-name-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 1;
+}
+
+.elev-station-lines {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.elev-station-line-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50% !important;
+}
+
+.elev-station-name {
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: var(--nm-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0;
+}
+
+/* Station Status Badge */
+.elev-station-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.elev-station-status--red {
+  background-color: rgba(255, 82, 82, 0.1);
+  color: var(--nm-status-error);
+  border: 1px solid rgba(255, 82, 82, 0.3);
+}
+
+.elev-station-status--red svg {
+  color: var(--nm-status-error);
+}
+
+.elev-station-status--yellow {
+  background-color: rgba(255, 179, 0, 0.1);
+  color: var(--nm-status-warn);
+  border: 1px solid rgba(255, 179, 0, 0.3);
+}
+
+.elev-station-status--yellow svg {
+  color: var(--nm-status-warn);
+}
+
+/* Station Counts */
+.elev-station-counts {
+  display: flex;
+  gap: var(--nm-space-md);
+  padding: 0.5rem 1.25rem;
+  border-bottom: 1px solid var(--nm-border-subtle);
+}
+
+.elev-station-count {
+  font-family: var(--nm-font);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.elev-station-count--elev {
+  color: var(--nm-status-error);
+}
+
+.elev-station-count--esc {
+  color: var(--nm-status-warn);
+}
+
+/* Individual Outages */
+.elev-station-outages {
+  padding: 0;
+}
+
+.elev-outage {
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--nm-border-subtle);
+}
+
+.elev-outage:last-child {
+  border-bottom: none;
+}
+
+.elev-outage-header {
+  display: flex;
+  align-items: center;
+  gap: var(--nm-space-sm);
+  flex-wrap: wrap;
+}
+
+.elev-outage-type {
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.elev-outage--elevator .elev-outage-type {
+  color: var(--nm-status-error);
+}
+
+.elev-outage--escalator .elev-outage-type {
+  color: var(--nm-status-warn);
+}
+
+.elev-outage-unit {
+  font-family: var(--nm-font);
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: var(--nm-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.elev-outage-time {
+  font-family: var(--nm-font);
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: var(--nm-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-left: auto;
+}
+
+.elev-outage-location {
+  font-family: var(--nm-font);
+  font-weight: 400;
+  font-size: 1rem;
+  color: var(--nm-text-secondary);
+  margin-top: 4px;
+  line-height: 1.5;
+}
+
+.elev-outage-symptom {
+  font-family: var(--nm-font);
+  font-weight: 400;
+  font-size: 0.875rem;
+  color: var(--nm-text-muted);
+  margin-top: 2px;
+}
+
+/* ---- Elevator Page Responsive ---- */
+@media (max-width: 768px) {
+  .elev-page {
+    padding: var(--nm-space-lg) var(--nm-space-md);
+  }
+
+  .elev-summary {
+    flex-direction: column;
+  }
+
+  .elev-summary-item {
+    min-width: unset;
+    border-right: none;
+    border-bottom: 1px solid var(--nm-border-subtle);
+    padding: var(--nm-space-sm) var(--nm-space-md);
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .elev-summary-item:last-child {
+    border-bottom: none;
+  }
+
+  .elev-summary-label {
+    margin-top: 0;
+  }
+
+  .elev-station-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--nm-space-sm);
+    padding: 0.6rem 1rem;
+  }
+
+  .elev-station-counts {
+    padding: 0.4rem 1rem;
+  }
+
+  .elev-outage {
+    padding: 0.6rem 1rem;
+  }
+
+  .elev-outage-header {
+    gap: var(--nm-space-xs);
+  }
+}

--- a/public/elevators/index.html
+++ b/public/elevators/index.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Metro Elevator &amp; Escalator Status — Live | NextMetro</title>
+  <meta name="description" id="meta-description" content="Live DC Metro elevator and escalator outage status. Filter by station, line, or unit type. See which stations are fully accessible right now. Updated every 30 seconds from WMATA." />
+  <link rel="canonical" href="https://nextmetro.live/elevators/" />
+  <link rel="stylesheet" href="/css/styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Metro Elevator & Escalator Status — Live | NextMetro" />
+  <meta property="og:description" content="Live DC Metro elevator and escalator outages. Filter by station or line. See which stations are fully accessible right now." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://nextmetro.live/elevators/" />
+  <meta property="og:site_name" content="NextMetro" />
+  <meta property="og:locale" content="en_US" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Metro Elevator & Escalator Status | NextMetro" />
+  <meta name="twitter:description" content="Live DC Metro elevator and escalator outages. Filter by station or line. See which stations are fully accessible." />
+
+  <!-- Schema: BreadcrumbList -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "https://nextmetro.live/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Elevators & Escalators",
+        "item": "https://nextmetro.live/elevators/"
+      }
+    ]
+  }
+  </script>
+
+  <!-- FAQPage structured data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "How many elevators and escalators does DC Metro have?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The DC Metro system has over 600 escalators and 300 elevators, one of the largest collections of any transit system in the world. Many were installed between 1976 and 2001 and are being replaced through a multi-year WMATA capital program."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Why are DC Metro escalators always broken?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Many Metro escalators are decades old and exposed to outdoor weather, heavy ridership, and the mechanical stress of serving some of the deepest stations in North America. Wheaton (230 feet deep) and Forest Glen (196 feet) have some of the longest single-span escalators in the Western Hemisphere. WMATA is in the middle of a system-wide escalator replacement program."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which Metro stations are wheelchair accessible when elevators are out?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "All Metro stations are designed to be ADA accessible, but when an elevator is out of service, some stations may lose their only accessible route between street level and the platform. Stations with a single elevator — such as many underground stations — become inaccessible to wheelchair users during outages. This page shows real-time elevator status so you can plan accessible routes."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How often is elevator and escalator status updated on NextMetro?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "NextMetro polls the WMATA Elevator and Escalator Incidents API every 30 seconds. Outage data includes the station, unit location, symptom, and the time the unit went out of service. Status updates appear on this page in real time without needing to refresh."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What should I do if a Metro elevator or escalator is broken?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "You can report broken elevators or escalators to WMATA by calling (202) 637-7000 or using the WMATA app. If you need an accessible route, check this page for real-time status at your station, or ask a station manager for assistance finding an alternative path to the platform."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What does the accessibility status mean on this page?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Green (All Working) means every elevator and escalator at the station is operational. Yellow (Partial Outage) means at least one unit is out of service but others are still working. Red (Elevator Out) specifically flags stations where an elevator is down, which may affect wheelchair accessibility."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+
+  <!-- NavBar -->
+  <header class="navbar" id="navbar">
+    <nav class="navbar-inner">
+      <a href="/" class="navbar-brand">
+        <span class="logo-mark">NEXT</span><span class="logo-wordmark">METRO</span>
+      </a>
+      <div class="navbar-links">
+        <a href="/alerts/" class="nav-link">Alerts</a>
+        <a href="/elevators/" class="nav-link nav-link--active">Elevators</a>
+        <a href="/fares/" class="nav-link">Fares</a>
+      </div>
+      <button class="navbar-toggle" id="navbar-toggle" aria-label="Toggle menu" aria-expanded="false">
+        <span class="navbar-toggle-bar"></span>
+        <span class="navbar-toggle-bar"></span>
+        <span class="navbar-toggle-bar"></span>
+      </button>
+    </nav>
+  </header>
+
+  <!-- Mobile Menu -->
+  <div class="mobile-menu" id="mobile-menu">
+    <a href="/alerts/" class="mobile-menu-link">Alerts</a>
+    <a href="/elevators/" class="mobile-menu-link mobile-menu-link--active">Elevators</a>
+    <a href="/fares/" class="mobile-menu-link">Fares</a>
+  </div>
+
+  <!-- System Ticker -->
+  <div class="ticker-bar" id="ticker-bar">
+    <div class="ticker-track" id="ticker-track"></div>
+  </div>
+
+  <!-- Page Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <span class="hero-label">Live Status</span>
+      <h1 class="hero-station-name">Elevator &amp; Escalator Outages</h1>
+      <p class="hero-station-address" id="elev-subtitle">Real-time elevator and escalator status for every DC Metro station — updated every 30 seconds.</p>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="elev-page">
+    <div class="elev-page-inner">
+
+      <!-- Controls Bar -->
+      <div class="alerts-controls animate-in d1">
+        <div class="alerts-controls-left">
+          <div class="elev-filters" id="elev-filters">
+            <!-- Type filter chips -->
+            <button class="elev-filter-chip elev-filter-chip--active" data-filter="all" aria-pressed="true">
+              <span class="elev-filter-label">All</span>
+            </button>
+            <button class="elev-filter-chip" data-filter="ELEVATOR" aria-pressed="false">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M7 2h10v20H7V2zm3 3v6h4V5h-4zm1 1h2v4h-2V6zM7 13h10v1H7v-1zm3 2v4h1v-3h2v3h1v-4h-4z"/></svg>
+              <span class="elev-filter-label">Elevators</span>
+            </button>
+            <button class="elev-filter-chip" data-filter="ESCALATOR" aria-pressed="false">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm-1 14l-4-4 1.41-1.41L11 14.17l6.59-6.59L19 9l-8 8z"/></svg>
+              <span class="elev-filter-label">Escalators</span>
+            </button>
+          </div>
+        </div>
+        <div class="alerts-controls-right">
+          <span class="alerts-updated" id="elev-updated"></span>
+          <button class="refresh-btn" id="elev-refresh" aria-label="Refresh status">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M17.65 6.35A7.958 7.958 0 0012 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0112 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/></svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- Summary Bar -->
+      <div class="elev-summary animate-in d2" id="elev-summary">
+        <!-- Rendered by JS -->
+      </div>
+
+      <!-- Line Filter Bar -->
+      <div class="elev-line-filters animate-in d2" id="elev-line-filters">
+        <button class="elev-line-chip elev-line-chip--active" data-line="all" aria-pressed="true">
+          <span class="elev-filter-label">All Lines</span>
+        </button>
+        <button class="elev-line-chip" data-line="RD" aria-pressed="false">
+          <span class="elev-line-dot" style="background-color:#BF0D3E"></span>
+          <span class="elev-filter-label">Red</span>
+        </button>
+        <button class="elev-line-chip" data-line="OR" aria-pressed="false">
+          <span class="elev-line-dot" style="background-color:#ED8B00"></span>
+          <span class="elev-filter-label">Orange</span>
+        </button>
+        <button class="elev-line-chip" data-line="BL" aria-pressed="false">
+          <span class="elev-line-dot" style="background-color:#009CDE"></span>
+          <span class="elev-filter-label">Blue</span>
+        </button>
+        <button class="elev-line-chip" data-line="GR" aria-pressed="false">
+          <span class="elev-line-dot" style="background-color:#00B140"></span>
+          <span class="elev-filter-label">Green</span>
+        </button>
+        <button class="elev-line-chip" data-line="YL" aria-pressed="false">
+          <span class="elev-line-dot" style="background-color:#FFD100"></span>
+          <span class="elev-filter-label">Yellow</span>
+        </button>
+        <button class="elev-line-chip" data-line="SV" aria-pressed="false">
+          <span class="elev-line-dot" style="background-color:#A2AAAD"></span>
+          <span class="elev-filter-label">Silver</span>
+        </button>
+      </div>
+
+      <!-- Station Groups -->
+      <div class="elev-stations" id="elev-stations" role="list" aria-label="Station elevator and escalator status">
+        <!-- Skeleton loading state -->
+        <div class="alerts-skeleton">
+          <div class="alerts-skeleton-card">
+            <div class="alerts-skeleton-block sk-title"></div>
+            <div class="alerts-skeleton-block sk-body"></div>
+            <div class="alerts-skeleton-block sk-body-short"></div>
+          </div>
+          <div class="alerts-skeleton-card">
+            <div class="alerts-skeleton-block sk-title"></div>
+            <div class="alerts-skeleton-block sk-body"></div>
+            <div class="alerts-skeleton-block sk-body-short"></div>
+          </div>
+          <div class="alerts-skeleton-card">
+            <div class="alerts-skeleton-block sk-title"></div>
+            <div class="alerts-skeleton-block sk-body"></div>
+            <div class="alerts-skeleton-block sk-body-short"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Empty State (hidden by default) -->
+      <div class="alerts-empty" id="elev-empty" style="display:none;">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor" class="alerts-empty-icon">
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+        </svg>
+        <span class="alerts-empty-title">All Clear</span>
+        <span class="alerts-empty-text">No elevator or escalator outages system-wide. All stations fully accessible.</span>
+      </div>
+
+    </div>
+  </main>
+
+  <!-- Crawlable last-updated timestamp for SEO freshness -->
+  <time id="elev-last-updated-time" datetime="" style="display:none;"></time>
+
+  <!-- Crawlable station list for SEO (hidden, populated by JS with all station names) -->
+  <div id="elev-seo-stations" aria-hidden="true" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;"></div>
+
+  <!-- FAQ Section -->
+  <section class="line-faq alerts-faq">
+    <div class="alerts-page-inner">
+      <h2 class="section-heading animate-in d3">Frequently Asked Questions</h2>
+      <p class="section-subheading animate-in d3">Accessibility, elevator reliability, and how to navigate the Metro when units are out of service.</p>
+      <div class="line-faq-list animate-in d4">
+
+        <details class="line-faq-item">
+          <summary class="line-faq-question">How many elevators and escalators does DC Metro have?</summary>
+          <div class="line-faq-answer">
+            <p>The DC Metro system has over 600 escalators and 300 elevators — one of the largest collections of any transit system in the world. Many were installed when the system opened between 1976 and 2001. WMATA is in the middle of a multi-year capital program to replace and modernize units across the system, prioritizing the oldest and highest-traffic stations.</p>
+          </div>
+        </details>
+
+        <details class="line-faq-item">
+          <summary class="line-faq-question">Why are Metro escalators always broken?</summary>
+          <div class="line-faq-answer">
+            <p>Many Metro escalators are decades old and face a combination of heavy daily ridership, outdoor weather exposure (rain, snow, debris), and the unique engineering demands of serving some of the deepest stations in North America. Wheaton (230 feet deep) and Forest Glen (196 feet) on the Red Line have some of the longest single-span escalators in the Western Hemisphere — these extra-long units are under far greater mechanical stress than standard escalators. WMATA's ongoing capital program is replacing the oldest units first, but the scale of the system means outages will continue during the modernization process.</p>
+          </div>
+        </details>
+
+        <details class="line-faq-item">
+          <summary class="line-faq-question">What should I do if I need an accessible station and the elevator is out?</summary>
+          <div class="line-faq-answer">
+            <p>If you rely on an elevator and it's out of service at your station, you have several options: check this page to find the nearest station with working elevators, ask a station manager for assistance (they can arrange accessible shuttle service in some cases), or contact WMATA at <a href="tel:+12026377000">(202) 637-7000</a> for real-time accessibility help. WMATA is required to provide alternative accessible routes when elevators are out of service at stations with no other accessible path.</p>
+          </div>
+        </details>
+
+        <details class="line-faq-item">
+          <summary class="line-faq-question">How often is this page updated?</summary>
+          <div class="line-faq-answer">
+            <p>This page polls the WMATA Elevator and Escalator Incidents API every 30 seconds. Outage data includes the station name, unit location within the station (e.g., "platform to mezzanine"), the reported symptom, and the time the unit went out of service. Updates appear in real time without needing to refresh the page.</p>
+          </div>
+        </details>
+
+        <details class="line-faq-item">
+          <summary class="line-faq-question">What do the status colors mean?</summary>
+          <div class="line-faq-answer">
+            <p><strong>Green (All Working)</strong> means every elevator and escalator at the station is operational — full accessibility. <strong>Yellow (Escalator Out)</strong> means one or more escalators are down but all elevators are working — the station remains wheelchair accessible. <strong>Red (Elevator Out)</strong> means at least one elevator is out of service, which may affect wheelchair and mobility-device access to the platform. Stations showing red should be approached with caution by riders who depend on elevators.</p>
+          </div>
+        </details>
+
+        <details class="line-faq-item">
+          <summary class="line-faq-question">How do I report a broken elevator or escalator?</summary>
+          <div class="line-faq-answer">
+            <p>You can report broken units to WMATA by calling <a href="tel:+12026377000">(202) 637-7000</a>, using the <a href="https://www.wmata.com/rider-guide/mobile-app.cfm" target="_blank" rel="noopener">WMATA mobile app</a>, or telling a station manager. Reports help WMATA prioritize repairs and dispatch maintenance crews. The outage data shown on this page comes from WMATA's official incident reporting system and may take a few minutes to reflect newly reported issues.</p>
+          </div>
+        </details>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <span class="footer-col-heading">Lines</span>
+          <div class="footer-lines-grid">
+            <a href="/lines/red/" class="footer-line-link"><span class="footer-line-dot" style="background-color: var(--nm-line-red)"></span>Red</a>
+            <a href="/lines/yellow/" class="footer-line-link"><span class="footer-line-dot" style="background-color: var(--nm-line-yellow)"></span>Yellow</a>
+            <a href="/lines/orange/" class="footer-line-link"><span class="footer-line-dot" style="background-color: var(--nm-line-orange)"></span>Orange</a>
+            <a href="/lines/green/" class="footer-line-link"><span class="footer-line-dot" style="background-color: var(--nm-line-green)"></span>Green</a>
+            <a href="/lines/blue/" class="footer-line-link"><span class="footer-line-dot" style="background-color: var(--nm-line-blue)"></span>Blue</a>
+            <a href="/lines/silver/" class="footer-line-link"><span class="footer-line-dot" style="background-color: var(--nm-line-silver)"></span>Silver</a>
+          </div>
+        </div>
+        <div class="footer-col">
+          <span class="footer-col-heading">Tools</span>
+          <a href="/alerts/">Alerts</a>
+          <a href="/elevators/">Elevators</a>
+          <a href="/hours/">Hours</a>
+        </div>
+        <div class="footer-col">
+          <span class="footer-col-heading">Support</span>
+          <a href="/about.html">About</a>
+          <a href="/help/">Help</a>
+          <a href="/crisis/">Crisis</a>
+        </div>
+        <div class="footer-col">
+          <span class="footer-col-heading">Legal</span>
+          <a href="/privacy/">Privacy</a>
+          <a href="/terms/">Terms</a>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>&copy; 2026 NextMetro &middot; Not affiliated with WMATA</span>
+        <a href="https://nickpoole.dev" target="_blank" rel="noopener">Webmaster</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="/js/nav.js"></script>
+  <script src="/js/elevators.js"></script>
+</body>
+</html>

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -69,7 +69,7 @@
       </a>
       <div class="navbar-links">
         <a href="/alerts/" class="nav-link">Alerts</a>
-        <a href="/map/" class="nav-link">Map</a>
+        <a href="/elevators/" class="nav-link">Elevators</a>
         <a href="/fares/" class="nav-link nav-link--active">Fares</a>
       </div>
       <button class="navbar-toggle" id="navbar-toggle" aria-label="Toggle menu" aria-expanded="false">
@@ -83,7 +83,7 @@
   <!-- Mobile Menu -->
   <div class="mobile-menu" id="mobile-menu">
     <a href="/alerts/" class="mobile-menu-link">Alerts</a>
-    <a href="/map/" class="mobile-menu-link">Map</a>
+    <a href="/elevators/" class="mobile-menu-link">Elevators</a>
     <a href="/fares/" class="mobile-menu-link mobile-menu-link--active">Fares</a>
   </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
       </a>
       <div class="navbar-links">
         <a href="/alerts/" class="nav-link">Alerts</a>
-        <a href="/map/" class="nav-link">Map</a>
+        <a href="/elevators/" class="nav-link">Elevators</a>
         <a href="/fares/" class="nav-link">Fares</a>
       </div>
       <button class="navbar-toggle" id="navbar-toggle" aria-label="Toggle menu" aria-expanded="false">
@@ -35,7 +35,7 @@
   <!-- Mobile Menu -->
   <div class="mobile-menu" id="mobile-menu">
     <a href="/alerts/" class="mobile-menu-link">Alerts</a>
-    <a href="/map/" class="mobile-menu-link">Map</a>
+    <a href="/elevators/" class="mobile-menu-link">Elevators</a>
     <a href="/fares/" class="mobile-menu-link">Fares</a>
   </div>
 

--- a/public/js/elevators.js
+++ b/public/js/elevators.js
@@ -1,0 +1,539 @@
+// ==============================
+// NextMetro — Elevator & Escalator Status Page
+// Station-grouped, filterable, real-time outage tracker
+// ==============================
+
+var API_BASE_URL = '';
+
+// ---- Fetch with retry (handles Render free-tier cold starts) ----
+async function fetchWithRetry(url, retries, delayMs) {
+  retries = retries || 2;
+  delayMs = delayMs || 3000;
+  for (var attempt = 0; attempt <= retries; attempt++) {
+    var res = await fetch(url);
+    if (res.ok) return res;
+    if (res.status !== 503 || attempt === retries) return res;
+    await new Promise(function (r) { setTimeout(r, delayMs * (attempt + 1)); });
+  }
+}
+
+// ---- Station code to line mapping ----
+var stationLines = {
+  A: ['RD'],
+  B: ['RD'],
+  C: ['BL', 'OR', 'SV'],
+  D: ['BL', 'OR', 'SV'],
+  E: ['GR', 'YL'],
+  F: ['GR', 'YL'],
+  G: ['BL', 'SV'],
+  J: ['BL', 'YL'],
+  K: ['OR', 'SV'],
+  N: ['SV'],
+  S: ['BL', 'YL'],
+};
+
+var lineColors = {
+  RD: '#BF0D3E',
+  BL: '#009CDE',
+  YL: '#FFD100',
+  OR: '#ED8B00',
+  GR: '#00B140',
+  SV: '#A2AAAD',
+};
+
+var lineNames = {
+  RD: 'Red',
+  BL: 'Blue',
+  YL: 'Yellow',
+  OR: 'Orange',
+  GR: 'Green',
+  SV: 'Silver',
+};
+
+// ---- State ----
+var currentOutages = [];
+var activeTypeFilter = 'all'; // 'all' | 'ELEVATOR' | 'ESCALATOR'
+var activeLineFilter = 'all'; // 'all' | line code
+var pollingInterval = null;
+
+// ---- DOM ----
+var tickerTrack = document.getElementById('ticker-track');
+var elevStations = document.getElementById('elev-stations');
+var elevEmpty = document.getElementById('elev-empty');
+var elevUpdated = document.getElementById('elev-updated');
+var elevRefresh = document.getElementById('elev-refresh');
+var elevSummary = document.getElementById('elev-summary');
+var elevFilters = document.getElementById('elev-filters');
+var elevLineFilters = document.getElementById('elev-line-filters');
+var metaDescription = document.getElementById('meta-description');
+var lastUpdatedTime = document.getElementById('elev-last-updated-time');
+var seoStations = document.getElementById('elev-seo-stations');
+
+// ==============================
+// Ticker (fetch rail incidents for line status)
+// ==============================
+async function fetchAndRenderTicker() {
+  try {
+    var res = await fetchWithRetry(API_BASE_URL + '/api/incidents');
+    if (!res || !res.ok) return;
+    var data = await res.json();
+    renderTicker(data.Incidents || []);
+  } catch (e) {
+    // Ticker is supplementary — fail silently
+  }
+}
+
+function parseAffectedLines(linesStr) {
+  if (!linesStr) return [];
+  return linesStr.split(';').map(function (s) { return s.trim(); }).filter(function (s) { return s.length > 0 && lineNames[s]; });
+}
+
+function renderTicker(incidents) {
+  var lineData = [
+    { code: 'RD', name: 'Red', color: '#BF0D3E' },
+    { code: 'OR', name: 'Orange', color: '#ED8B00' },
+    { code: 'BL', name: 'Blue', color: '#009CDE' },
+    { code: 'GR', name: 'Green', color: '#00B140' },
+    { code: 'YL', name: 'Yellow', color: '#FFD100' },
+    { code: 'SV', name: 'Silver', color: '#A2AAAD' },
+  ];
+
+  var lineStatuses = {};
+  lineData.forEach(function (l) { lineStatuses[l.code] = 'Normal'; });
+
+  (incidents || []).forEach(function (incident) {
+    var affectedLines = parseAffectedLines(incident.LinesAffected);
+    var status = incident.IncidentType === 'Delay' ? 'Alert' : 'Caution';
+    affectedLines.forEach(function (lineCode) {
+      if (lineStatuses[lineCode]) {
+        if (status === 'Alert' || lineStatuses[lineCode] === 'Normal') {
+          lineStatuses[lineCode] = status;
+        }
+      }
+    });
+  });
+
+  var html = '';
+  for (var i = 0; i < 2; i++) {
+    lineData.forEach(function (line) {
+      var thisStatus = lineStatuses[line.code];
+      var statusClass =
+        thisStatus === 'Normal'
+          ? 'ticker-status-ok'
+          : thisStatus === 'Alert'
+            ? 'ticker-status-alert'
+            : 'ticker-status-caution';
+      html +=
+        '<span class="ticker-item">' +
+        '<span class="ticker-dot" style="background-color:' + line.color + '"></span>' +
+        '<span>' + line.name + '</span>' +
+        '<span class="' + statusClass + '">' + thisStatus + '</span>' +
+        '</span>';
+    });
+  }
+
+  tickerTrack.innerHTML = html;
+}
+
+// ==============================
+// HTML Escaping
+// ==============================
+function escapeHtml(str) {
+  var div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+// ==============================
+// Get lines for a station code
+// ==============================
+function getLinesForStation(stationCode) {
+  if (!stationCode) return [];
+  var prefix = stationCode.charAt(0);
+  return stationLines[prefix] || [];
+}
+
+// ==============================
+// Time Formatting
+// ==============================
+function formatOutageTime(dateStr) {
+  if (!dateStr) return '';
+  var date = new Date(dateStr);
+  if (isNaN(date.getTime())) return '';
+  var now = new Date();
+  var diffMs = now - date;
+  var diffMin = Math.floor(diffMs / 60000);
+
+  if (diffMin < 1) return 'Just now';
+  if (diffMin < 60) return diffMin + 'm ago';
+  var diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return diffHr + 'h ago';
+  var diffDay = Math.floor(diffHr / 24);
+  return diffDay + 'd ago';
+}
+
+// ==============================
+// Group outages by station
+// ==============================
+function groupByStation(outages) {
+  var groups = {};
+  var order = [];
+
+  outages.forEach(function (outage) {
+    var station = outage.StationName || 'Unknown Station';
+    var code = outage.StationCode || '';
+
+    if (!groups[station]) {
+      groups[station] = {
+        station: station,
+        stationCode: code,
+        lines: getLinesForStation(code),
+        outages: [],
+        elevatorOut: 0,
+        escalatorOut: 0,
+      };
+      order.push(station);
+    }
+
+    groups[station].outages.push(outage);
+    if ((outage.UnitType || '').toUpperCase() === 'ELEVATOR') {
+      groups[station].elevatorOut++;
+    } else {
+      groups[station].escalatorOut++;
+    }
+  });
+
+  // Sort: elevator outages first (accessibility critical), then by outage count
+  order.sort(function (a, b) {
+    var aElev = groups[a].elevatorOut;
+    var bElev = groups[b].elevatorOut;
+    if (aElev !== bElev) return bElev - aElev;
+    return groups[b].outages.length - groups[a].outages.length;
+  });
+
+  return order.map(function (name) { return groups[name]; });
+}
+
+// ==============================
+// Apply filters
+// ==============================
+function getFilteredOutages() {
+  var filtered = currentOutages;
+
+  // Type filter
+  if (activeTypeFilter !== 'all') {
+    filtered = filtered.filter(function (o) {
+      return (o.UnitType || '').toUpperCase() === activeTypeFilter;
+    });
+  }
+
+  // Line filter
+  if (activeLineFilter !== 'all') {
+    filtered = filtered.filter(function (o) {
+      var lines = getLinesForStation(o.StationCode || '');
+      return lines.indexOf(activeLineFilter) !== -1;
+    });
+  }
+
+  return filtered;
+}
+
+// ==============================
+// Render Summary Bar
+// ==============================
+function renderSummary() {
+  var total = currentOutages.length;
+  var elevCount = 0;
+  var escalCount = 0;
+  var stationSet = new Set();
+
+  currentOutages.forEach(function (o) {
+    if ((o.UnitType || '').toUpperCase() === 'ELEVATOR') elevCount++;
+    else escalCount++;
+    if (o.StationName) stationSet.add(o.StationName);
+  });
+
+  if (total === 0) {
+    elevSummary.innerHTML =
+      '<div class="elev-summary-item elev-summary-item--ok">' +
+      '<span class="elev-summary-value">0</span>' +
+      '<span class="elev-summary-label">Outages</span>' +
+      '</div>' +
+      '<div class="elev-summary-item">' +
+      '<span class="elev-summary-value elev-summary-value--ok">All Working</span>' +
+      '<span class="elev-summary-label">System Status</span>' +
+      '</div>';
+    return;
+  }
+
+  elevSummary.innerHTML =
+    '<div class="elev-summary-item">' +
+    '<span class="elev-summary-value">' + total + '</span>' +
+    '<span class="elev-summary-label">Total Outage' + (total !== 1 ? 's' : '') + '</span>' +
+    '</div>' +
+    '<div class="elev-summary-item">' +
+    '<span class="elev-summary-value">' + elevCount + '</span>' +
+    '<span class="elev-summary-label">Elevator' + (elevCount !== 1 ? 's' : '') + '</span>' +
+    '</div>' +
+    '<div class="elev-summary-item">' +
+    '<span class="elev-summary-value">' + escalCount + '</span>' +
+    '<span class="elev-summary-label">Escalator' + (escalCount !== 1 ? 's' : '') + '</span>' +
+    '</div>' +
+    '<div class="elev-summary-item">' +
+    '<span class="elev-summary-value">' + stationSet.size + '</span>' +
+    '<span class="elev-summary-label">Station' + (stationSet.size !== 1 ? 's' : '') + ' Affected</span>' +
+    '</div>';
+}
+
+// ==============================
+// Render Station Cards
+// ==============================
+function renderStations() {
+  var filtered = getFilteredOutages();
+
+  if (filtered.length === 0) {
+    elevStations.innerHTML = '';
+    elevEmpty.style.display = '';
+    // Update empty state text based on filters
+    var emptyTitle = elevEmpty.querySelector('.alerts-empty-title');
+    var emptyText = elevEmpty.querySelector('.alerts-empty-text');
+    if (activeTypeFilter !== 'all' || activeLineFilter !== 'all') {
+      emptyTitle.textContent = 'No Matching Outages';
+      emptyText.textContent = 'No outages match your current filters. Try adjusting or clearing filters.';
+    } else {
+      emptyTitle.textContent = 'All Clear';
+      emptyText.textContent = 'No elevator or escalator outages system-wide. All stations fully accessible.';
+    }
+    return;
+  }
+
+  elevEmpty.style.display = 'none';
+  var groups = groupByStation(filtered);
+  var html = '';
+
+  groups.forEach(function (group, idx) {
+    var delay = Math.min(idx * 0.04, 0.5);
+    var hasElevOut = group.elevatorOut > 0;
+    var statusClass = hasElevOut ? 'elev-station--elevator-out' : 'elev-station--escalator-out';
+    var statusLabel = hasElevOut ? 'Elevator Out' : 'Escalator Out';
+    var statusIcon = hasElevOut
+      ? '<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>'
+      : '<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/></svg>';
+
+    // Line dots for this station
+    var lineDots = '';
+    group.lines.forEach(function (lineCode) {
+      lineDots += '<span class="elev-station-line-dot" style="background-color:' + (lineColors[lineCode] || '#888') + '" title="' + (lineNames[lineCode] || '') + ' Line"></span>';
+    });
+
+    html += '<article class="elev-station-card ' + statusClass + ' animate-in" style="animation-delay:' + delay + 's" role="listitem">';
+
+    // Station header
+    html +=
+      '<div class="elev-station-header">' +
+      '<div class="elev-station-name-row">' +
+      '<div class="elev-station-lines">' + lineDots + '</div>' +
+      '<h2 class="elev-station-name">' + escapeHtml(group.station) + '</h2>' +
+      '</div>' +
+      '<div class="elev-station-status ' + (hasElevOut ? 'elev-station-status--red' : 'elev-station-status--yellow') + '">' +
+      statusIcon +
+      '<span>' + statusLabel + '</span>' +
+      '</div>' +
+      '</div>';
+
+    // Outage count summary
+    html += '<div class="elev-station-counts">';
+    if (group.elevatorOut > 0) {
+      html += '<span class="elev-station-count elev-station-count--elev">' + group.elevatorOut + ' elevator' + (group.elevatorOut !== 1 ? 's' : '') + ' out</span>';
+    }
+    if (group.escalatorOut > 0) {
+      html += '<span class="elev-station-count elev-station-count--esc">' + group.escalatorOut + ' escalator' + (group.escalatorOut !== 1 ? 's' : '') + ' out</span>';
+    }
+    html += '</div>';
+
+    // Individual outages
+    html += '<div class="elev-station-outages">';
+    group.outages.forEach(function (outage) {
+      var unitType = (outage.UnitType || '').toUpperCase();
+      var typeLabel = unitType === 'ELEVATOR' ? 'Elevator' : 'Escalator';
+      var typeClass = unitType === 'ELEVATOR' ? 'elev-outage--elevator' : 'elev-outage--escalator';
+      var location = outage.LocationDescription || '';
+      var symptom = outage.SymptomDescription || '';
+      var unit = outage.UnitName || '';
+      var timeStr = formatOutageTime(outage.DateOutOfServ || outage.DateUpdated || '');
+
+      html +=
+        '<div class="elev-outage ' + typeClass + '">' +
+        '<div class="elev-outage-header">' +
+        '<span class="elev-outage-type">' + typeLabel + '</span>' +
+        (unit ? '<span class="elev-outage-unit">' + escapeHtml(unit) + '</span>' : '') +
+        (timeStr ? '<span class="elev-outage-time">' + escapeHtml(timeStr) + '</span>' : '') +
+        '</div>' +
+        (location ? '<div class="elev-outage-location">' + escapeHtml(location) + '</div>' : '') +
+        (symptom ? '<div class="elev-outage-symptom">' + escapeHtml(symptom) + '</div>' : '') +
+        '</div>';
+    });
+    html += '</div>';
+
+    html += '</article>';
+  });
+
+  elevStations.innerHTML = html;
+}
+
+// ==============================
+// SEO: Update meta description & crawlable station text
+// ==============================
+function updateSEO() {
+  var total = currentOutages.length;
+  var desc;
+  if (total === 0) {
+    desc = 'All DC Metro elevators and escalators operating normally. No outages reported. Live status updates at NextMetro.';
+  } else {
+    var stationSet = new Set();
+    var elevCount = 0;
+    var escalCount = 0;
+    currentOutages.forEach(function (o) {
+      if (o.StationName) stationSet.add(o.StationName);
+      if ((o.UnitType || '').toUpperCase() === 'ELEVATOR') elevCount++;
+      else escalCount++;
+    });
+    var parts = [];
+    if (elevCount > 0) parts.push(elevCount + ' elevator' + (elevCount !== 1 ? 's' : ''));
+    if (escalCount > 0) parts.push(escalCount + ' escalator' + (escalCount !== 1 ? 's' : ''));
+    desc = total + ' outage' + (total !== 1 ? 's' : '') + ' (' + parts.join(', ') +
+      ') at ' + stationSet.size + ' station' + (stationSet.size !== 1 ? 's' : '') +
+      '. Live DC Metro elevator & escalator status at NextMetro.';
+  }
+
+  if (metaDescription) {
+    metaDescription.setAttribute('content', desc);
+  }
+
+  // Crawlable timestamp
+  var now = new Date();
+  if (lastUpdatedTime) {
+    lastUpdatedTime.setAttribute('datetime', now.toISOString());
+    lastUpdatedTime.textContent = now.toISOString();
+  }
+
+  // Crawlable station names for SEO (long-tail "[station] elevator" queries)
+  if (seoStations && currentOutages.length > 0) {
+    var stationNames = [];
+    var seen = new Set();
+    currentOutages.forEach(function (o) {
+      var name = o.StationName || '';
+      if (name && !seen.has(name)) {
+        seen.add(name);
+        stationNames.push(name);
+      }
+    });
+    seoStations.textContent = 'Current elevator and escalator outages at: ' + stationNames.join(', ') + '.';
+  } else if (seoStations) {
+    seoStations.textContent = '';
+  }
+}
+
+// ==============================
+// Update Timestamp
+// ==============================
+function updateTimestamp() {
+  var now = new Date();
+  var timeStr = now.toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  elevUpdated.textContent = 'Updated ' + timeStr;
+}
+
+// ==============================
+// Fetch All Outages
+// ==============================
+async function fetchOutages() {
+  try {
+    var res = await fetchWithRetry(API_BASE_URL + '/api/elevators');
+    if (!res || !res.ok) throw new Error('API error');
+    var data = await res.json();
+    currentOutages = data.ElevatorIncidents || [];
+  } catch (e) {
+    console.error('Failed to fetch elevator incidents:', e.message);
+    // Keep existing data on error
+  }
+
+  renderSummary();
+  renderStations();
+  updateTimestamp();
+  updateSEO();
+}
+
+// ==============================
+// Filter Event Handlers
+// ==============================
+elevFilters.addEventListener('click', function (e) {
+  var chip = e.target.closest('.elev-filter-chip');
+  if (!chip) return;
+  var filter = chip.dataset.filter;
+  if (!filter) return;
+
+  activeTypeFilter = filter;
+
+  // Update active states
+  var chips = elevFilters.querySelectorAll('.elev-filter-chip');
+  chips.forEach(function (c) {
+    var isActive = c.dataset.filter === filter;
+    c.classList.toggle('elev-filter-chip--active', isActive);
+    c.setAttribute('aria-pressed', String(isActive));
+  });
+
+  renderStations();
+});
+
+elevLineFilters.addEventListener('click', function (e) {
+  var chip = e.target.closest('.elev-line-chip');
+  if (!chip) return;
+  var line = chip.dataset.line;
+  if (!line) return;
+
+  activeLineFilter = line;
+
+  // Update active states
+  var chips = elevLineFilters.querySelectorAll('.elev-line-chip');
+  chips.forEach(function (c) {
+    var isActive = c.dataset.line === line;
+    c.classList.toggle('elev-line-chip--active', isActive);
+    c.setAttribute('aria-pressed', String(isActive));
+  });
+
+  renderStations();
+});
+
+elevRefresh.addEventListener('click', function () {
+  fetchOutages();
+  fetchAndRenderTicker();
+});
+
+// ==============================
+// Polling
+// ==============================
+function startPolling() {
+  if (pollingInterval) clearInterval(pollingInterval);
+  pollingInterval = setInterval(function () {
+    fetchOutages();
+  }, 30000);
+}
+
+// ==============================
+// Init
+// ==============================
+document.addEventListener('DOMContentLoaded', async function () {
+  // Wake up backend
+  try {
+    await fetchWithRetry(API_BASE_URL + '/healthz', 3, 2000);
+  } catch (e) {
+    // Backend may be sleeping
+  }
+
+  await Promise.all([fetchOutages(), fetchAndRenderTicker()]);
+  startPolling();
+});

--- a/public/lines/red/index.html
+++ b/public/lines/red/index.html
@@ -197,7 +197,7 @@
       </a>
       <div class="navbar-links">
         <a href="/alerts/" class="nav-link">Alerts</a>
-        <a href="/map/" class="nav-link">Map</a>
+        <a href="/elevators/" class="nav-link">Elevators</a>
         <a href="/fares/" class="nav-link">Fares</a>
       </div>
       <button class="navbar-toggle" id="navbar-toggle" aria-label="Toggle menu" aria-expanded="false">
@@ -211,7 +211,7 @@
   <!-- Mobile Menu -->
   <div class="mobile-menu" id="mobile-menu">
     <a href="/alerts/" class="mobile-menu-link">Alerts</a>
-    <a href="/map/" class="mobile-menu-link">Map</a>
+    <a href="/elevators/" class="mobile-menu-link">Elevators</a>
     <a href="/fares/" class="mobile-menu-link">Fares</a>
   </div>
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -38,9 +38,9 @@
   </url>
   <url>
     <loc>https://nextmetro.live/elevators/</loc>
-    <lastmod>2026-02-24</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.7</priority>
+    <lastmod>2026-02-26</lastmod>
+    <changefreq>always</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nextmetro.live/about.html</loc>


### PR DESCRIPTION
New dedicated page for real-time WMATA elevator and escalator outage
tracking with station-grouped view, type and line filters, color-coded
accessibility status (green/yellow/red), and 30-second auto-refresh.

- Station-grouped cards with elevator-out (red) vs escalator-out (yellow)
- Filter by unit type (All/Elevators/Escalators) and by Metro line
- Summary bar showing total outages, elevator/escalator split, stations affected
- SEO: FAQPage schema, dynamic meta description, crawlable station names
- WCAG: aria-pressed on filter chips, role=list on station container
- Update nav across all pages: replace Map link with Elevators
- Sitemap updated with priority 0.9 and changefreq=always

https://claude.ai/code/session_01GB4cWzEhfEu8caJrvr2hWg