### PR TITLE
Add station pages for Metro Center and Potomac Yard

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 NextMetro displays live train arrivals, system status, service alerts, station facility conditions, and fare information — styled after the Metro's own visual language of concrete vault ceilings, pylon signage, and PIDS boards.
 
-**[Live Site](https://nextmetro.live)** · **[API Backend](https://nextmetro.onrender.com)**
+**[Live Site](https://nextmetro.live)**
 
 ---
 
@@ -19,6 +19,8 @@ NextMetro displays live train arrivals, system status, service alerts, station f
 - **Elevator & Escalator Status Page** — Dedicated [elevator & escalator page](https://nextmetro.live/elevators/) with station-grouped outage view, type filters (elevators/escalators), line filters, color-coded accessibility status (green = all working, yellow = escalator out, red = elevator out), summary bar, and 6-question FAQ with FAQPage structured data. Crawlable station names for long-tail SEO. Also shown per-station on the main arrivals page.
 - **Fare Calculator** — Interactive fare lookup between any two stations showing peak, off-peak, and senior/disabled pricing with estimated travel time.
 - **Line Pages** — Dedicated pages for each Metro line with real-time arrivals, station lists with transfer/parking badges, service hours, frequency info, and an FAQ section with structured data for SEO. Currently live: [Red Line](https://nextmetro.live/lines/red/).
+- **Station Pages** — Dedicated station pages with real-time PIDS arrivals, station info, adjacent stations, and FAQ sections with Schema.org structured data (TrainStation, FAQPage, BreadcrumbList). Transfer stations (Metro Center, Gallery Place) feature dual side-by-side PIDS boards — one per physical platform — with separate WMATA API calls. Currently live: [Brookland-CUA](https://nextmetro.live/station/brookland-cua/), [Potomac Yard](https://nextmetro.live/station/potomac-yard/), [Metro Center](https://nextmetro.live/station/metro-center/), [Gallery Place-Chinatown](https://nextmetro.live/station/gallery-place/), [Union Station](https://nextmetro.live/station/union-station/).
+- **Station Search Navigation** — Selecting a station from the search dropdown navigates directly to that station's dedicated page when available.
 
 ---
 
@@ -27,22 +29,10 @@ NextMetro displays live train arrivals, system status, service alerts, station f
 | Layer | Technology |
 |-------|-----------|
 | **Frontend** | Vanilla HTML5, CSS, JavaScript |
-| **Backend** | Express.js v5 (Node.js) |
+| **Backend** | Cloudflare Workers |
 | **API** | [WMATA Real-Time Rail API](https://developer.wmata.com/) |
 | **Typography** | Rajdhani (Google Fonts) |
-| **Frontend Hosting** | Netlify (static, no build step) |
-| **Backend Hosting** | Render |
-
-### Dependencies
-
-| Package | Purpose |
-|---------|---------|
-| `express` | HTTP server and static file serving |
-| `node-fetch` | Server-side HTTP requests to WMATA API |
-| `cors` | Cross-origin request handling |
-| `dotenv` | Environment variable management |
-| `helmet` | HTTP security headers |
-| `express-rate-limit` | API rate limiting (60 req/min per IP) |
+| **Hosting** | Cloudflare (Workers + static assets) |
 
 ---
 
@@ -50,49 +40,60 @@ NextMetro displays live train arrivals, system status, service alerts, station f
 
 ```
 nextmetro/
-├── server.js              Express backend (API proxy + cache + static serving)
+├── src/
+│   └── index.js           Cloudflare Workers backend (API proxy + cache)
+├── wrangler.toml          Cloudflare Workers config
 ├── package.json
-├── .env.example           Environment variable template
 ├── .gitignore
 ├── LICENSE                MIT
 ├── README.md
 ├── SECURITY.md            Security policy and measures
-├── render.yaml            Render deployment config
-└── public/                Static frontend (served by Express and Netlify)
+└── public/                Static frontend (served by Cloudflare)
     ├── index.html         Main arrivals app
     ├── about.html         About page
     ├── 404.html           Custom 404 page
     ├── robots.txt
     ├── sitemap.xml
-    ├── netlify.toml       Netlify deploy config + API proxy redirects
     ├── alerts/
     │   └── index.html     Service alerts page (rail + elevator/escalator, FAQ)
     ├── elevators/
     │   └── index.html     Elevator & escalator status page (station-grouped, filtered)
     ├── fares/
     │   └── index.html     Fare calculator page
+    ├── hours/
+    │   └── index.html     Service hours page
     ├── lines/
-    │   └── red/
-    │       └── index.html Red Line page (stations, service info, FAQ)
+    │   ├── red/
+    │   ├── blue/
+    │   ├── orange/
+    │   ├── green/
+    │   ├── yellow/
+    │   └── silver/        Line pages (stations, service info, FAQ)
+    ├── station/
+    │   ├── brookland-cua/  Standard station page (Red Line)
+    │   ├── potomac-yard/   Standard station page (Blue/Yellow)
+    │   ├── metro-center/   Transfer station — dual PIDS (Red + Or/Bl/Sv)
+    │   ├── gallery-place/  Transfer station — dual PIDS (Red + Gr/Yl)
+    │   └── union-station/  Standard station page (Red Line)
     ├── css/
     │   ├── styles.css     Full design system
     │   ├── nav.css        Navigation component styles
     │   └── footer.css     Footer component styles
     ├── js/
-    │   ├── app.js         Application logic (~1,070 lines)
-    │   ├── alerts.js      Alerts page — fetches rail + elevator incidents (~360 lines)
-    │   ├── elevators.js   Elevator/escalator page — station-grouped, filtered (~420 lines)
-    │   ├── nav.js         Shared navigation bar component (~30 lines)
-    │   ├── line.js        Line page logic — arrivals, alerts, FAQ toggle (~355 lines)
-    │   └── fares.js       Fare calculator logic (~410 lines)
-    └── images/            Photography assets (16 images)
+    │   ├── app.js         Application logic (arrivals, transfer PIDS, station nav)
+    │   ├── alerts.js      Alerts page logic
+    │   ├── elevators.js   Elevator/escalator page logic
+    │   ├── nav.js         Shared navigation bar component
+    │   ├── line.js        Line page logic
+    │   └── fares.js       Fare calculator logic
+    └── images/            Photography assets
 ```
 
-### API Routes (server.js)
+### API Routes (Cloudflare Workers)
 
 | Route | Description | Cache |
 |-------|-------------|-------|
-| `GET /healthz` | Health check (uptime, API key status) | None |
+| `GET /healthz` | Health check | None |
 | `GET /api/stations` | All WMATA stations | Infinite |
 | `GET /api/station/:code` | Single station info | Infinite |
 | `GET /api/predictions/:code` | Real-time train arrivals | None (live) |
@@ -101,10 +102,9 @@ nextmetro/
 | `GET /api/elevators/:code` | Elevator/escalator outages per station | 120s TTL |
 | `GET /api/fare/:from/:to` | Fare info between stations | 1hr TTL |
 
-### Deployment Model
+### Deployment
 
-- **Netlify** serves the `public/` directory as a static site with no build step. API requests (`/api/*`) are proxied to the Render backend via `netlify.toml` redirects.
-- **Render** hosts the Express server which proxies WMATA API requests with the API key stored as an environment variable.
+Cloudflare Workers serves both the static frontend and the API proxy. The WMATA API key is stored as a Workers secret.
 
 ---
 
@@ -155,6 +155,19 @@ The visual design — **Concrete Vault** — is based on the architectural ident
 ---
 
 ## Changelog
+
+### v2.6.0 — Station Pages & Search Navigation
+
+- Add 5 dedicated station pages: Brookland-CUA, Potomac Yard, Metro Center, Gallery Place-Chinatown, Union Station
+- Transfer station dual PIDS: Metro Center and Gallery Place render two side-by-side arrival boards (one per physical platform) with separate WMATA API calls
+- Station pages include real-time arrivals, station info, adjacent stations, and FAQ accordions
+- Schema.org structured data on all station pages: TrainStation, FAQPage, BreadcrumbList
+- SEO optimization: OG/Twitter meta tags, canonical URLs, and meta descriptions on all station pages
+- Search navigation: selecting a station from the search dropdown now navigates to its dedicated page
+- Transfer station CSS: `.pids-grid` two-column layout, line strip headers, transfer badge
+- Station FAQ accordion styles with expand/collapse toggle
+- Sitemap updated with all 5 station pages
+- README updated to reflect Cloudflare Workers architecture (migrated from Express/Netlify/Render)
 
 ### v2.5.0 — Site-Wide Compliance, Accessibility & SEO Hardening
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1143,6 +1143,126 @@ a:hover {
 }
 
 /* ==============================
+   Station FAQ
+   ============================== */
+.station-faq {
+  background-color: var(--nm-surface);
+  border: 1px solid var(--nm-border);
+  padding: var(--nm-space-lg);
+  margin-top: var(--nm-space-lg);
+}
+
+.station-faq-title {
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: 1.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--nm-text-primary);
+  margin-bottom: var(--nm-space-md);
+}
+
+.station-faq-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--nm-space-sm);
+}
+
+.station-faq-item {
+  border: 1px solid var(--nm-border-subtle);
+  background-color: var(--nm-surface-elevated);
+}
+
+.station-faq-question {
+  font-family: var(--nm-font);
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--nm-text-primary);
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--nm-space-sm);
+}
+
+.station-faq-question::after {
+  content: '+';
+  font-size: 1.25rem;
+  color: var(--nm-amber);
+  flex-shrink: 0;
+}
+
+.station-faq-item[open] .station-faq-question::after {
+  content: '\2212';
+}
+
+.station-faq-question::-webkit-details-marker {
+  display: none;
+}
+
+.station-faq-answer {
+  font-family: var(--nm-font);
+  font-size: 0.95rem;
+  color: var(--nm-text-secondary);
+  padding: 0 1rem 0.75rem;
+  line-height: 1.6;
+}
+
+/* ==============================
+   Transfer Station PIDS Grid
+   ============================== */
+.pids-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 640px) {
+  .pids-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pids-grid .pids-card {
+  margin-bottom: 0;
+}
+
+.pids-header .line-strip-group {
+  display: flex;
+  gap: 2px;
+}
+
+.pids-header .line-strip {
+  width: 5px;
+  height: 20px;
+}
+
+.pids-header .platform-label {
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--nm-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+/* Transfer station badge in hero */
+.hero-transfer-badge {
+  display: inline-block;
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--nm-amber);
+  border: 1px solid var(--nm-amber-dim);
+  padding: 0.15rem 0.5rem;
+  margin-top: var(--nm-space-xs);
+}
+
+/* ==============================
    Adjacent Stations Card
    ============================== */
 .adjacent-card {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -262,11 +262,27 @@ const fareSenior = document.getElementById('fare-senior');
 const fareTime = document.getElementById('fare-time');
 
 // Build station options array (deduplicate multi-platform stations)
-const stationOptions = Object.entries(stations).map(([code, name]) => ({
-  code,
-  name,
-  lines: prefixLines[code.charAt(0)] || [],
-}));
+const stationOptions = (() => {
+  const seen = {};
+  const result = [];
+  Object.entries(stations).forEach(([code, name]) => {
+    const lines = prefixLines[code.charAt(0)] || [];
+    if (seen[name]) {
+      // Merge lines from the partner platform code
+      const existing = seen[name];
+      lines.forEach((line) => {
+        if (!existing.lines.some((l) => l.code === line.code)) {
+          existing.lines.push(line);
+        }
+      });
+    } else {
+      const entry = { code, name, lines: lines.slice() };
+      seen[name] = entry;
+      result.push(entry);
+    }
+  });
+  return result;
+})();
 
 // Get all line codes that serve a station (including multi-platform partner)
 function getStationLineCodes(stationCode) {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -211,7 +211,8 @@ const prefixLines = {
 };
 
 // ---- State ----
-let selectedStation = 'B05';
+// Station pages can set STATION_CODE before loading app.js to override the default
+let selectedStation = (typeof STATION_CODE !== 'undefined') ? STATION_CODE : 'B05';
 let predictionsInterval = null;
 let incidentsInterval = null;
 let facilitiesInterval = null;
@@ -912,8 +913,8 @@ function updateTimestamp() {
 // Fetch Train Predictions (with directional grouping)
 // ==============================
 async function fetchTrains(stationCode) {
-  if (!stationCode) {
-    pidsContent.innerHTML = '';
+  if (!stationCode || !pidsContent) {
+    if (pidsContent) pidsContent.innerHTML = '';
     lastUpdatedEl.style.display = 'none';
     return;
   }
@@ -971,14 +972,118 @@ async function fetchTrains(stationCode) {
 }
 
 // ==============================
+// Transfer Station: Dual PIDS Board Rendering
+// ==============================
+function renderPlatformSkeletons(contentEl) {
+  contentEl.innerHTML = '';
+  var colHeaders = document.createElement('div');
+  colHeaders.className = 'pids-col-headers';
+  colHeaders.innerHTML =
+    '<span>LN</span><span>CAR</span><span>DEST</span><span style="text-align:right">MIN</span>';
+  contentEl.appendChild(colHeaders);
+  for (var i = 0; i < 3; i++) {
+    var row = document.createElement('div');
+    row.className = 'pids-skeleton-row';
+    row.innerHTML =
+      '<div class="pids-skeleton-block sk-line"></div>' +
+      '<div class="pids-skeleton-block sk-cars"></div>' +
+      '<div class="pids-skeleton-block sk-dest"></div>' +
+      '<div class="pids-skeleton-block sk-min"></div>';
+    contentEl.appendChild(row);
+  }
+}
+
+function renderPlatformPids(contentEl, trains) {
+  contentEl.innerHTML = '';
+
+  // Column headers
+  var colHeaders = document.createElement('div');
+  colHeaders.className = 'pids-col-headers';
+  colHeaders.innerHTML =
+    '<span>LN</span><span>CAR</span><span>DEST</span><span style="text-align:right">MIN</span>';
+  contentEl.appendChild(colHeaders);
+
+  if (trains.length === 0) {
+    var empty = document.createElement('div');
+    empty.className = 'pids-empty';
+    empty.innerHTML = '<span>No trains scheduled</span>';
+    contentEl.appendChild(empty);
+    return;
+  }
+
+  // Show max 3 rows per platform board
+  trains.slice(0, 3).forEach(function (train) {
+    contentEl.appendChild(createPidsRow(train));
+  });
+}
+
+async function fetchTransferTrains() {
+  if (typeof TRANSFER_PLATFORMS === 'undefined') return;
+
+  var platforms = TRANSFER_PLATFORMS;
+
+  // Show skeletons on first load for each platform
+  platforms.forEach(function (platform) {
+    var el = document.getElementById(platform.contentEl);
+    if (el && !el.querySelector('.pids-row')) {
+      renderPlatformSkeletons(el);
+    }
+  });
+
+  try {
+    // Make separate API calls for each platform (never merge)
+    var fetches = platforms.map(function (platform) {
+      var code = platform.wmataCodes[0];
+      return fetchWithRetry(API_BASE_URL + '/api/predictions/' + code)
+        .then(function (res) {
+          if (!res.ok) throw new Error('API error');
+          return res.json();
+        });
+    });
+
+    var results = await Promise.all(fetches);
+    lastUpdatedTime = new Date();
+
+    results.forEach(function (data, i) {
+      var platform = platforms[i];
+      var el = document.getElementById(platform.contentEl);
+      if (!el) return;
+
+      var validTrains = data.filter(function (t) {
+        return t.line && t.line !== 'No' && t.line !== '--' && t.destination;
+      }).sort(sortByMin);
+
+      renderPlatformPids(el, validTrains);
+    });
+
+    updateTimestamp();
+  } catch (err) {
+    platforms.forEach(function (platform) {
+      var el = document.getElementById(platform.contentEl);
+      if (el) {
+        el.innerHTML =
+          '<div class="pids-empty">' +
+          '<span>Error: ' + escapeHtml(err.message || 'Fetch failed') + '</span>' +
+          '</div>';
+      }
+    });
+  }
+}
+
+// ==============================
 // Polling Management
 // ==============================
 function startPolling() {
   stopPolling();
 
   // Predictions: every 25 seconds
+  var isTransfer = (typeof IS_TRANSFER_STATION !== 'undefined') && IS_TRANSFER_STATION;
   predictionsInterval = setInterval(() => {
-    if (selectedStation) fetchTrains(selectedStation);
+    if (isTransfer) {
+      fetchTransferTrains();
+    } else if (selectedStation) {
+      fetchTrains(selectedStation);
+    }
   }, 25000);
 
   // Incidents: every 60 seconds
@@ -1020,7 +1125,12 @@ function updateSystemStatusTime() {
 // ==============================
 refreshBtn.addEventListener('click', () => {
   if (selectedStation) {
-    fetchTrains(selectedStation);
+    var isTransfer = (typeof IS_TRANSFER_STATION !== 'undefined') && IS_TRANSFER_STATION;
+    if (isTransfer) {
+      fetchTransferTrains();
+    } else {
+      fetchTrains(selectedStation);
+    }
     fetchIncidents();
     fetchFacilities(selectedStation);
   }
@@ -1050,7 +1160,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   // Initial data fetches
-  fetchTrains(selectedStation);
+  var isTransfer = (typeof IS_TRANSFER_STATION !== 'undefined') && IS_TRANSFER_STATION;
+  if (isTransfer) {
+    fetchTransferTrains();
+  } else {
+    fetchTrains(selectedStation);
+  }
   fetchIncidents();
   fetchFacilities(selectedStation);
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -141,6 +141,18 @@ const multiPlatform = {
   E06: 'B06',
 };
 
+// ---- Station Pages ----
+// Stations that have dedicated pages — maps station code to URL slug
+const stationPages = {
+  B05: 'brookland-cua',
+  C11: 'potomac-yard',
+  A01: 'metro-center',
+  C01: 'metro-center',
+  B01: 'gallery-place',
+  F01: 'gallery-place',
+  B03: 'union-station',
+};
+
 // ---- Metro Line Colors ----
 const lineColors = {
   RD: '#D41140',
@@ -730,6 +742,13 @@ function filterStations(query) {
 }
 
 function selectStation(option) {
+  // Navigate to dedicated station page if one exists
+  var slug = stationPages[option.code];
+  if (slug) {
+    window.location.href = '/station/' + slug + '/';
+    return;
+  }
+
   selectedStation = option.code;
   stationInput.value = '';
   stationDropdown.classList.remove('open');

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -89,4 +89,28 @@
     <changefreq>always</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://nextmetro.live/station/potomac-yard/</loc>
+    <lastmod>2026-03-13</lastmod>
+    <changefreq>always</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://nextmetro.live/station/metro-center/</loc>
+    <lastmod>2026-03-13</lastmod>
+    <changefreq>always</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://nextmetro.live/station/gallery-place/</loc>
+    <lastmod>2026-03-13</lastmod>
+    <changefreq>always</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://nextmetro.live/station/union-station/</loc>
+    <lastmod>2026-03-13</lastmod>
+    <changefreq>always</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/public/station/brookland-cua/index.html
+++ b/public/station/brookland-cua/index.html
@@ -3,13 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Brookland-CUA — Real-Time Metro Arrivals | NextMetro</title>
-  <meta name="description" content="Live train arrivals and real-time predictions for Brookland-CUA Metro station on the Red Line. Track next trains, check elevator status, and calculate fares." />
+  <title>Brookland-CUA Station — Real-Time Arrivals, Fares & Info | NextMetro</title>
+  <meta name="description" content="Live train arrivals for Brookland-CUA Metro station on the Red Line in Washington, DC. Real-time PIDS board, fare calculator, elevator status, and service alerts for Brookland and Catholic University of America." />
+  <meta name="robots" content="index, follow" />
+  <meta name="keywords" content="Brookland-CUA Metro station, Red Line arrivals, DC Metro train times, Brookland Metro, Catholic University Metro, WMATA real-time, Metro station near CUA, Brookland train schedule" />
   <link rel="canonical" href="https://nextmetro.live/station/brookland-cua/" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Brookland-CUA — Real-Time Metro Arrivals | NextMetro" />
-  <meta property="og:description" content="Live train arrivals and real-time predictions for Brookland-CUA Metro station on the Red Line." />
+  <meta property="og:title" content="Brookland-CUA Station — Live Red Line Arrivals | NextMetro" />
+  <meta property="og:description" content="Real-time Red Line arrivals for Brookland-CUA Metro station. Live PIDS board, fares, elevator status, and service alerts." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://nextmetro.live/station/brookland-cua/" />
   <meta property="og:site_name" content="NextMetro" />
@@ -21,8 +23,8 @@
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Brookland-CUA — Real-Time Metro Arrivals | NextMetro" />
-  <meta name="twitter:description" content="Live train arrivals and real-time predictions for Brookland-CUA Metro station on the Red Line." />
+  <meta name="twitter:title" content="Brookland-CUA Station — Live Red Line Arrivals | NextMetro" />
+  <meta name="twitter:description" content="Real-time Red Line arrivals for Brookland-CUA Metro station. Live PIDS board, fares, elevator status, and service alerts." />
   <meta name="twitter:image" content="https://nextmetro.live/images/og/stations/og-station-brookland-cua.png" />
 
   <!-- Favicon -->
@@ -73,11 +75,25 @@
       "@context": "https://schema.org",
       "@type": "TrainStation",
       "name": "Brookland-CUA",
-      "alternateName": "Brookland–Catholic University of America",
+      "alternateName": ["Brookland–Catholic University of America", "Brookland Metro Station"],
+      "description": "Brookland-CUA is a ground-level Metrorail station on the Red Line in Washington, DC, serving the Brookland, Edgewood, and Catholic University of America neighborhoods.",
       "url": "https://nextmetro.live/station/brookland-cua/",
+      "sameAs": "https://www.wmata.com/rider-guide/stations/brookland.cfm",
+      "image": "https://nextmetro.live/images/og/stations/og-station-brookland-cua.png",
       "hasMap": "https://wmata.com/schedules/maps/upload/system-map-rail.pdf",
       "isAccessibleForFree": false,
       "publicAccess": true,
+      "smokingAllowed": false,
+      "wheelchair": true,
+      "amenityFeature": [
+        { "@type": "LocationFeatureSpecification", "name": "Elevator", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "Escalator", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "Bicycle Parking", "value": true }
+      ],
+      "containedInPlace": {
+        "@type": "City",
+        "name": "Washington, DC"
+      },
       "address": {
         "@type": "PostalAddress",
         "streetAddress": "801 Michigan Ave NE",
@@ -115,6 +131,52 @@
           "dayOfWeek": "Sunday",
           "opens": "07:00",
           "closes": "00:00"
+        }
+      ]
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What Metro line serves Brookland-CUA station?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Brookland-CUA is served by the Red Line, running between Shady Grove and Glenmont. It is located between Rhode Island Ave-Brentwood and Fort Totten stations."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Where is Brookland-CUA Metro station?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Brookland-CUA station is located at 801 Michigan Ave NE, Washington, DC 20017, in the Brookland neighborhood near the Catholic University of America campus."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does Brookland-CUA station have parking?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Brookland-CUA station does not have a WMATA-operated parking garage. Street parking and nearby private lots are available in the surrounding neighborhood."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What are the hours of operation for Brookland-CUA station?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Brookland-CUA station is open Monday through Thursday from 5:00 AM to midnight, Friday from 5:00 AM to 1:00 AM, Saturday from 7:00 AM to 1:00 AM, and Sunday from 7:00 AM to midnight."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What bus lines connect at Brookland-CUA station?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Brookland-CUA station is served by Metrobus routes H2, H3, H4, H8, and H9, connecting riders to neighborhoods including Crosstown, Brookland, and points along Michigan Avenue."
+          }
         }
       ]
     }
@@ -319,6 +381,33 @@
               <span class="fare-result-value" id="fare-time">--</span>
             </div>
           </div>
+        </div>
+      </section>
+
+      <!-- Station FAQ -->
+      <section class="station-faq animate-in d5">
+        <h2 class="station-faq-title">Frequently Asked Questions</h2>
+        <div class="station-faq-list">
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What Metro line serves Brookland-CUA station?</summary>
+            <p class="station-faq-answer">Brookland-CUA is served by the Red Line, running between Shady Grove and Glenmont. It is located between Rhode Island Ave-Brentwood and Fort Totten stations.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">Where is Brookland-CUA Metro station?</summary>
+            <p class="station-faq-answer">Brookland-CUA station is located at 801 Michigan Ave NE, Washington, DC 20017, in the Brookland neighborhood near the Catholic University of America campus.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">Does Brookland-CUA station have parking?</summary>
+            <p class="station-faq-answer">Brookland-CUA station does not have a WMATA-operated parking garage. Street parking and nearby private lots are available in the surrounding neighborhood.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What are the hours of operation for Brookland-CUA station?</summary>
+            <p class="station-faq-answer">Brookland-CUA station is open Monday through Thursday from 5:00 AM to midnight, Friday from 5:00 AM to 1:00 AM, Saturday from 7:00 AM to 1:00 AM, and Sunday from 7:00 AM to midnight.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What bus lines connect at Brookland-CUA station?</summary>
+            <p class="station-faq-answer">Brookland-CUA station is served by Metrobus routes H2, H3, H4, H8, and H9, connecting riders to neighborhoods including Crosstown, Brookland, and points along Michigan Avenue.</p>
+          </details>
         </div>
       </section>
 

--- a/public/station/brookland-cua/index.html
+++ b/public/station/brookland-cua/index.html
@@ -6,8 +6,7 @@
   <title>Brookland-CUA Station — Real-Time Arrivals, Fares & Info | NextMetro</title>
   <meta name="description" content="Live train arrivals for Brookland-CUA Metro station on the Red Line in Washington, DC. Real-time PIDS board, fare calculator, elevator status, and service alerts for Brookland and Catholic University of America." />
   <meta name="robots" content="index, follow" />
-  <meta name="keywords" content="Brookland-CUA Metro station, Red Line arrivals, DC Metro train times, Brookland Metro, Catholic University Metro, WMATA real-time, Metro station near CUA, Brookland train schedule" />
-  <link rel="canonical" href="https://nextmetro.live/station/brookland-cua/" />
+<link rel="canonical" href="https://nextmetro.live/station/brookland-cua/" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Brookland-CUA Station — Live Red Line Arrivals | NextMetro" />

--- a/public/station/gallery-place/index.html
+++ b/public/station/gallery-place/index.html
@@ -1,0 +1,487 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gallery Pl-Chinatown Station — Real-Time Arrivals, Transfers & Info | NextMetro</title>
+  <meta name="description" content="Live dual-platform arrivals for Gallery Pl-Chinatown transfer station in Washington, DC. Red, Green, and Yellow Line PIDS boards side by side. Fare calculator, elevator status, transfer info, and service alerts." />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://nextmetro.live/station/gallery-place/" />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Gallery Pl-Chinatown Station — Live Red, Green & Yellow Arrivals | NextMetro" />
+  <meta property="og:description" content="Real-time dual-platform arrivals for Gallery Pl-Chinatown transfer station. Red, Green, and Yellow Line PIDS boards, fares, and service alerts." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://nextmetro.live/station/gallery-place/" />
+  <meta property="og:site_name" content="NextMetro" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://nextmetro.live/images/og/stations/og-station-gallery-place.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="Gallery Pl-Chinatown Station — Real-Time Metro Arrivals | NextMetro" />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Gallery Pl-Chinatown Station — Live Red, Green & Yellow Arrivals | NextMetro" />
+  <meta name="twitter:description" content="Real-time dual-platform arrivals for Gallery Pl-Chinatown transfer station. Red, Green, and Yellow Line PIDS boards, fares, and service alerts." />
+  <meta name="twitter:image" content="https://nextmetro.live/images/og/stations/og-station-gallery-place.png" />
+
+  <!-- Favicon -->
+  <link rel="icon" href="/favicon.ico" sizes="48x48" />
+  <link rel="icon" href="/images/icons/nm-mark.svg" type="image/svg+xml" />
+  <link rel="icon" href="/images/icons/favicon-32x32.png" sizes="32x32" type="image/png" />
+  <link rel="icon" href="/images/icons/favicon-16x16.png" sizes="16x16" type="image/png" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <meta name="theme-color" content="#0A0A0A" />
+
+  <link rel="stylesheet" href="/css/styles.css" />
+  <link rel="stylesheet" href="/css/nav.css" />
+  <link rel="stylesheet" href="/css/footer.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/remixicon@4.6.0/fonts/remixicon.css" rel="stylesheet" />
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  [
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "NextMetro", "item": "https://nextmetro.live/" },
+        { "@type": "ListItem", "position": 2, "name": "Red Line", "item": "https://nextmetro.live/lines/red/" },
+        { "@type": "ListItem", "position": 3, "name": "Gallery Pl-Chinatown", "item": "https://nextmetro.live/station/gallery-place/" }
+      ]
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "TrainStation",
+      "name": "Gallery Pl-Chinatown",
+      "alternateName": ["Gallery Place-Chinatown", "Gallery Place Metro Station", "Chinatown Metro"],
+      "description": "Gallery Pl-Chinatown is an underground transfer station in Washington, DC, serving the Red, Green, and Yellow Lines. It features two platforms and is located adjacent to Capital One Arena in the Penn Quarter/Chinatown neighborhood.",
+      "url": "https://nextmetro.live/station/gallery-place/",
+      "sameAs": "https://www.wmata.com/rider-guide/stations/gallery-pl.cfm",
+      "image": "https://nextmetro.live/images/og/stations/og-station-gallery-place.png",
+      "hasMap": "https://wmata.com/schedules/maps/upload/system-map-rail.pdf",
+      "isAccessibleForFree": false,
+      "publicAccess": true,
+      "smokingAllowed": false,
+      "wheelchair": true,
+      "amenityFeature": [
+        { "@type": "LocationFeatureSpecification", "name": "Elevator", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "Escalator", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "Transfer Between Lines", "value": true }
+      ],
+      "containedInPlace": { "@type": "City", "name": "Washington, DC" },
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "630 H St NW",
+        "addressLocality": "Washington",
+        "addressRegion": "DC",
+        "postalCode": "20001",
+        "addressCountry": "US"
+      },
+      "geo": { "@type": "GeoCoordinates", "latitude": 38.8983, "longitude": -77.0219 },
+      "openingHoursSpecification": [
+        { "@type": "OpeningHoursSpecification", "dayOfWeek": ["Monday","Tuesday","Wednesday","Thursday"], "opens": "05:00", "closes": "00:00" },
+        { "@type": "OpeningHoursSpecification", "dayOfWeek": "Friday", "opens": "05:00", "closes": "01:00" },
+        { "@type": "OpeningHoursSpecification", "dayOfWeek": "Saturday", "opens": "07:00", "closes": "01:00" },
+        { "@type": "OpeningHoursSpecification", "dayOfWeek": "Sunday", "opens": "07:00", "closes": "00:00" }
+      ]
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What Metro lines serve Gallery Pl-Chinatown station?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Gallery Pl-Chinatown is a transfer station served by the Red, Green, and Yellow Lines. Platform A serves the Red Line and Platform B serves the Green and Yellow Lines." }
+        },
+        {
+          "@type": "Question",
+          "name": "How do I transfer between lines at Gallery Pl-Chinatown?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Gallery Pl-Chinatown has two platforms connected by escalators and elevators within the station. Platform A serves the Red Line (Shady Grove–Glenmont), and Platform B serves the Green and Yellow Lines. Follow the signs to transfer without leaving the fare gates." }
+        },
+        {
+          "@type": "Question",
+          "name": "What is near Gallery Pl-Chinatown station?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Gallery Pl-Chinatown is located adjacent to Capital One Arena and in the heart of Washington DC's Chinatown and Penn Quarter neighborhoods. Nearby attractions include the National Portrait Gallery, International Spy Museum, and numerous restaurants and shops along 7th Street NW." }
+        },
+        {
+          "@type": "Question",
+          "name": "What are the hours of operation for Gallery Pl-Chinatown station?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Gallery Pl-Chinatown station is open Monday through Thursday from 5:00 AM to midnight, Friday from 5:00 AM to 1:00 AM, Saturday from 7:00 AM to 1:00 AM, and Sunday from 7:00 AM to midnight." }
+        }
+      ]
+    }
+  ]
+  </script>
+</head>
+<body>
+
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- NextMetro Site Nav -->
+  <nav class="nm-nav" aria-label="Site navigation">
+    <div class="nm-nav__strip" aria-hidden="true">
+      <span></span><span></span><span></span><span></span><span></span><span></span>
+    </div>
+    <a href="/" class="nm-nav__logo" aria-label="NextMetro home">
+      <span class="nm-nav__logo-next">NEXT</span>
+      <span class="nm-nav__logo-divider" aria-hidden="true"></span>
+      <span class="nm-nav__logo-metro">METRO</span>
+    </a>
+    <div class="nm-nav__links">
+      <a href="/alerts" class="nm-nav__link">Alerts</a>
+      <a href="https://wmata.com/schedules/maps/upload/system-map-rail.pdf" class="nm-nav__link" target="_blank" rel="noopener noreferrer" title="System Map (PDF, opens in new tab)" aria-label="System Map (PDF, opens in new tab)">Map</a>
+      <a href="/fares" class="nm-nav__link">Fares</a>
+      <a href="/hours" class="nm-nav__link">Hours</a>
+    </div>
+    <button class="nm-nav__hamburger" id="navbar-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-menu">
+      <span></span><span></span><span></span>
+    </button>
+  </nav>
+  <div class="nm-mobile-menu" id="mobile-menu">
+    <a href="/alerts" class="mobile-menu-link">Alerts</a>
+    <a href="https://wmata.com/schedules/maps/upload/system-map-rail.pdf" class="mobile-menu-link" target="_blank" rel="noopener noreferrer" title="System Map (PDF, opens in new tab)" aria-label="System Map (PDF, opens in new tab)">Map</a>
+    <a href="/fares" class="mobile-menu-link">Fares</a>
+    <a href="/hours" class="mobile-menu-link">Hours</a>
+  </div>
+
+  <!-- Hero / Station Header -->
+  <section class="hero hero--has-image" id="hero">
+    <div class="hero__image" aria-hidden="true">
+      <img src="/images/gallery-place-chinatown.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
+    </div>
+    <div class="hero-inner">
+      <nav class="hero-breadcrumb" aria-label="Breadcrumb">
+        <a href="/">Home</a>
+        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
+        <a href="/lines/red/">Red Line</a>
+        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
+        <span class="hero-breadcrumb__current">Gallery Pl-Chinatown</span>
+      </nav>
+      <span class="hero-label">Station</span>
+      <h1 class="hero-station-name" id="hero-station-name">Gallery Pl-Chinatown</h1>
+      <p class="hero-station-desc" id="hero-station-desc">Chinatown, Penn Quarter &amp; Capital One Arena.</p>
+      <span class="hero-transfer-badge">Transfer Station</span>
+
+      <!-- Line Pills -->
+      <div class="line-pills" id="line-pills"></div>
+    </div>
+  </section>
+
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input type="text" id="station-input" class="station-search__input" placeholder="Search stations..." autocomplete="off" aria-label="Search for a Metro station" />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
+  <!-- Main Content -->
+  <main id="main-content" class="main-grid">
+    <div class="main-column">
+
+      <!-- Dual PIDS Grid — Two platforms side by side -->
+      <div class="pids-grid animate-in d1">
+
+        <!-- Platform A: Red Line -->
+        <section class="pids-card" id="pids-card-a">
+          <div class="pids-header">
+            <div class="line-strip-group">
+              <div class="line-strip" style="background: var(--nm-line-red)"></div>
+            </div>
+            <span class="platform-label">Platform A · Red Line</span>
+          </div>
+          <div class="pids-screen">
+            <div class="pids-scanlines"></div>
+            <div class="pids-content" id="pids-content-a"></div>
+          </div>
+        </section>
+
+        <!-- Platform B: Green / Yellow -->
+        <section class="pids-card" id="pids-card-b">
+          <div class="pids-header">
+            <div class="line-strip-group">
+              <div class="line-strip" style="background: var(--nm-line-green)"></div>
+              <div class="line-strip" style="background: var(--nm-line-yellow)"></div>
+            </div>
+            <span class="platform-label">Platform B · Gr / Yl</span>
+          </div>
+          <div class="pids-screen">
+            <div class="pids-scanlines"></div>
+            <div class="pids-content" id="pids-content-b"></div>
+          </div>
+        </section>
+
+      </div>
+
+      <!-- Last Updated -->
+      <div class="last-updated" id="last-updated" style="display:none;">
+        <span id="updated-time"></span>
+        <button class="refresh-btn" id="refresh-btn" aria-label="Refresh train data">
+          <i class="ri-refresh-line" aria-hidden="true"></i>
+        </button>
+      </div>
+
+      <!-- Station Info -->
+      <section class="station-info-card animate-in d3">
+        <div class="station-info-header">
+          <h2 class="station-info-title">Station Information</h2>
+        </div>
+        <div class="station-info-body">
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-map-pin-line" aria-hidden="true"></i></span>
+            <span class="station-info-label">Address</span>
+            <span class="station-info-value">630 H St NW, Washington, DC 20001</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-indeterminate-circle-line" aria-hidden="true"></i></span>
+            <span class="station-info-label">Station Type</span>
+            <span class="station-info-value">Underground · Transfer Station</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-door-open-line" aria-hidden="true"></i></span>
+            <span class="station-info-label">Entrances</span>
+            <span class="station-info-value">7th &amp; H St NW, 7th &amp; F St NW, 9th &amp; G St NW</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-parking-box-line" aria-hidden="true"></i></span>
+            <span class="station-info-label">Parking</span>
+            <span class="station-info-value">Not available</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-time-fill" aria-hidden="true"></i></span>
+            <span class="station-info-label">Hours</span>
+            <span class="station-info-value station-info-value--hours">
+              <span>Mon–Thu: 5:00 AM – 12:00 AM</span>
+              <span>Fri: 5:00 AM – 1:00 AM</span>
+              <span>Sat: 7:00 AM – 1:00 AM</span>
+              <span>Sun: 7:00 AM – 12:00 AM</span>
+            </span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-map-2-fill" aria-hidden="true"></i></span>
+            <span class="station-info-label">Neighborhood</span>
+            <span class="station-info-value">Chinatown, Penn Quarter</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-bus-fill" aria-hidden="true"></i></span>
+            <span class="station-info-label">Bus Lines</span>
+            <span class="station-info-value">70, 74, P6, X2</span>
+          </div>
+        </div>
+        <div class="station-info-actions">
+          <a href="https://www.google.com/maps/dir/?api=1&destination=38.8983,-77.0219" class="station-info-link" target="_blank" rel="noopener noreferrer">
+            <i class="ri-direction-line" aria-hidden="true"></i> Directions
+          </a>
+          <a href="https://www.wmata.com/rider-guide/stations/gallery-pl.cfm" class="station-info-link" target="_blank" rel="noopener noreferrer">
+            <i class="ri-external-link-line" aria-hidden="true"></i> WMATA Station Page
+          </a>
+        </div>
+      </section>
+
+      <!-- Fare Calculator -->
+      <section class="fare-card animate-in d4" id="fare-card">
+        <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
+        <div class="fare-body">
+          <div class="fare-route">
+            <div class="fare-station fare-from">
+              <span class="fare-station-label">From</span>
+              <span class="fare-station-name" id="fare-from-name">Gallery Pl-Chinatown</span>
+            </div>
+            <div class="fare-arrow"><i class="ri-arrow-right-box-fill" aria-hidden="true"></i></div>
+            <div class="fare-station fare-to">
+              <span class="fare-station-label">To</span>
+              <select id="fare-destination" class="fare-select" aria-label="Select destination station">
+                <option value="">Select destination...</option>
+              </select>
+            </div>
+          </div>
+          <div class="fare-results" id="fare-results" style="display:none;">
+            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Station FAQ -->
+      <section class="station-faq animate-in d5">
+        <h2 class="station-faq-title">Frequently Asked Questions</h2>
+        <div class="station-faq-list">
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What Metro lines serve Gallery Pl-Chinatown station?</summary>
+            <p class="station-faq-answer">Gallery Pl-Chinatown is a transfer station served by the Red, Green, and Yellow Lines. Platform A serves the Red Line and Platform B serves the Green and Yellow Lines.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">How do I transfer between lines at Gallery Pl-Chinatown?</summary>
+            <p class="station-faq-answer">Gallery Pl-Chinatown has two platforms connected by escalators and elevators within the station. Platform A serves the Red Line (Shady Grove–Glenmont), and Platform B serves the Green and Yellow Lines. Follow the signs to transfer without leaving the fare gates.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What is near Gallery Pl-Chinatown station?</summary>
+            <p class="station-faq-answer">Gallery Pl-Chinatown is located adjacent to Capital One Arena and in the heart of Washington DC's Chinatown and Penn Quarter neighborhoods. Nearby attractions include the National Portrait Gallery, International Spy Museum, and numerous restaurants and shops along 7th Street NW.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What are the hours of operation for Gallery Pl-Chinatown station?</summary>
+            <p class="station-faq-answer">Gallery Pl-Chinatown station is open Monday through Thursday from 5:00 AM to midnight, Friday from 5:00 AM to 1:00 AM, Saturday from 7:00 AM to 1:00 AM, and Sunday from 7:00 AM to midnight.</p>
+          </details>
+        </div>
+      </section>
+
+    </div>
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+
+      <!-- Adjacent Stations — Red Line -->
+      <section class="adjacent-card animate-in d2">
+        <div class="adjacent-header">
+          <h2 class="adjacent-title">Adjacent Stations</h2>
+          <span class="adjacent-line-badge adjacent-line-badge--red">Red Line</span>
+        </div>
+        <div class="adjacent-body">
+          <a href="/station/metro-center/" class="adjacent-station adjacent-station--prev">
+            <span class="adjacent-direction"><i class="ri-arrow-left-s-line" aria-hidden="true"></i> Toward Shady Grove</span>
+            <span class="adjacent-name">Metro Center</span>
+          </a>
+          <div class="adjacent-divider"><span class="adjacent-current-dot"></span></div>
+          <a href="/station/judiciary-square/" class="adjacent-station adjacent-station--next">
+            <span class="adjacent-direction">Toward Glenmont <i class="ri-arrow-right-s-line" aria-hidden="true"></i></span>
+            <span class="adjacent-name">Judiciary Square</span>
+          </a>
+        </div>
+      </section>
+
+      <!-- Adjacent Stations — Green / Yellow Lines -->
+      <section class="adjacent-card animate-in d2">
+        <div class="adjacent-header">
+          <h2 class="adjacent-title">Adjacent Stations</h2>
+          <span class="adjacent-line-badge adjacent-line-badge--green">Gr</span>
+          <span class="adjacent-line-badge adjacent-line-badge--yellow">Yl</span>
+        </div>
+        <div class="adjacent-body">
+          <a href="/station/archives/" class="adjacent-station adjacent-station--prev">
+            <span class="adjacent-direction"><i class="ri-arrow-left-s-line" aria-hidden="true"></i> Toward Branch Ave / Huntington</span>
+            <span class="adjacent-name">Archives-Navy Memorial</span>
+          </a>
+          <div class="adjacent-divider"><span class="adjacent-current-dot"></span></div>
+          <a href="/station/mt-vernon-sq/" class="adjacent-station adjacent-station--next">
+            <span class="adjacent-direction">Toward Greenbelt / Mt Vernon Sq <i class="ri-arrow-right-s-line" aria-hidden="true"></i></span>
+            <span class="adjacent-name">Mt Vernon Sq</span>
+          </a>
+        </div>
+      </section>
+
+      <!-- Station Facilities Card -->
+      <section class="facilities-card animate-in d3" id="facilities-card">
+        <div class="facilities-header"><h2 class="facilities-title">Station Facilities</h2></div>
+        <div class="facilities-body" id="facilities-body">
+          <div class="facilities-row">
+            <span class="facilities-icon"><i class="ri-arrow-up-down-line" aria-hidden="true"></i></span>
+            <span class="facilities-label">Elevators</span>
+            <span class="facilities-status facilities-status--ok" id="elevator-status">Operational</span>
+          </div>
+          <div class="facilities-row">
+            <span class="facilities-icon"><i class="ri-escalator-line" aria-hidden="true"></i></span>
+            <span class="facilities-label">Escalators</span>
+            <span class="facilities-status facilities-status--ok" id="escalator-status">Operational</span>
+          </div>
+        </div>
+        <div class="facilities-details" id="facilities-details" style="display:none;"></div>
+      </section>
+
+      <!-- System Status Card -->
+      <div class="system-status-card animate-in d2" id="system-status-card">
+        <div class="system-status-header">
+          <span>System Status</span>
+          <span class="system-status-time" id="system-status-time"></span>
+        </div>
+        <div class="system-status-rows" id="system-status-rows"></div>
+      </div>
+
+      <!-- Alert Card -->
+      <div class="alert-card animate-in d3" id="alert-card" style="display:none;">
+        <div class="alert-card-header">
+          <span class="alert-badge">Service Alert</span>
+          <span class="alert-timestamp" id="alert-timestamp"></span>
+        </div>
+        <div class="alert-card-body" id="alert-body"></div>
+      </div>
+
+    </aside>
+  </main>
+
+  <!-- NextMetro Site Footer -->
+  <footer class="nm-footer">
+    <div class="nm-footer__strip" aria-hidden="true">
+      <span></span><span></span><span></span><span></span><span></span><span></span>
+    </div>
+    <div class="nm-footer__body">
+      <div class="nm-footer__col">
+        <h2 class="nm-footer__heading">Navigate</h2>
+        <nav class="nm-footer__links" aria-label="Footer navigation">
+          <a href="/" class="nm-footer__link">Home</a>
+          <a href="https://wmata.com/schedules/maps/upload/system-map-rail.pdf" class="nm-footer__link" target="_blank" rel="noopener noreferrer" title="System Map (PDF, opens in new tab)" aria-label="System Map (PDF, opens in new tab)">System Map</a>
+          <a href="/alerts" class="nm-footer__link">Alerts</a>
+          <a href="/elevators" class="nm-footer__link">Elevator Status</a>
+          <a href="/fares" class="nm-footer__link">Fares</a>
+          <a href="/hours" class="nm-footer__link">Hours</a>
+        </nav>
+      </div>
+      <div class="nm-footer__col">
+        <h2 class="nm-footer__heading">Lines</h2>
+        <nav class="nm-footer__links" aria-label="Metro lines">
+          <a href="/lines/red" class="nm-footer__link nm-footer__link--line"><span class="nm-footer__dot nm-footer__dot--red"></span>Red Line</a>
+          <a href="/lines/orange" class="nm-footer__link nm-footer__link--line"><span class="nm-footer__dot nm-footer__dot--orange"></span>Orange Line</a>
+          <a href="/lines/silver" class="nm-footer__link nm-footer__link--line"><span class="nm-footer__dot nm-footer__dot--silver"></span>Silver Line</a>
+          <a href="/lines/blue" class="nm-footer__link nm-footer__link--line"><span class="nm-footer__dot nm-footer__dot--blue"></span>Blue Line</a>
+          <a href="/lines/yellow" class="nm-footer__link nm-footer__link--line"><span class="nm-footer__dot nm-footer__dot--yellow"></span>Yellow Line</a>
+          <a href="/lines/green" class="nm-footer__link nm-footer__link--line"><span class="nm-footer__dot nm-footer__dot--green"></span>Green Line</a>
+        </nav>
+      </div>
+      <div class="nm-footer__col">
+        <h2 class="nm-footer__heading">About</h2>
+        <nav class="nm-footer__links" aria-label="About">
+          <a href="/about" class="nm-footer__link">About NextMetro</a>
+          <a href="/privacy" class="nm-footer__link">Privacy Policy</a>
+          <a href="/terms" class="nm-footer__link">Terms of Service</a>
+          <a href="/crisis" class="nm-footer__link">Crisis Resources</a>
+          <a href="https://nickpoole.dev" class="nm-footer__link" target="_blank" rel="noopener noreferrer">Webmaster</a>
+        </nav>
+        <div class="nm-footer__data-block">
+          <h2 class="nm-footer__heading">Data</h2>
+          <p class="nm-footer__body-text">Real-time data via WMATA API.<br>Not affiliated with WMATA.</p>
+        </div>
+      </div>
+      <div class="nm-footer__col nm-footer__col--logo">
+        <div class="nm-footer__logo" role="img" aria-label="NextMetro">
+          <div class="nm-footer__logo-mark"><b>NM</b></div>
+          <div class="nm-footer__logo-strip" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span><span></span></div>
+          <div class="nm-footer__logo-text">
+            <span class="nm-footer__logo-next">NEXT</span>
+            <span class="nm-footer__logo-metro">METRO</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="nm-footer__bottom">
+      <span class="nm-footer__copy">&copy; 2026 NextMetro &middot; nextmetro.live</span>
+    </div>
+  </footer>
+  <script src="/js/nav.js"></script>
+  <script>
+  const STATION_CODE = 'B01';
+  const IS_TRANSFER_STATION = true;
+  const TRANSFER_PLATFORMS = [
+    { label: 'Platform A \u00B7 Red Line', lines: ['RD'], wmataCodes: ['B01'], contentEl: 'pids-content-a' },
+    { label: 'Platform B \u00B7 Gr / Yl', lines: ['GR', 'YL'], wmataCodes: ['F01'], contentEl: 'pids-content-b' }
+  ];
+  </script>
+  <script src="/js/app.js"></script>
+</body>
+</html>

--- a/public/station/metro-center/index.html
+++ b/public/station/metro-center/index.html
@@ -6,8 +6,7 @@
   <title>Metro Center Station — Real-Time Arrivals, Transfers & Info | NextMetro</title>
   <meta name="description" content="Live dual-platform arrivals for Metro Center transfer station in downtown Washington, DC. Red, Orange, Blue, and Silver Line PIDS boards side by side. Fare calculator, elevator status, transfer info, and service alerts." />
   <meta name="robots" content="index, follow" />
-  <meta name="keywords" content="Metro Center station, DC Metro transfer, Red Line arrivals, Orange Line arrivals, Blue Line arrivals, Silver Line arrivals, downtown DC Metro, WMATA real-time, Metro Center platform, Metro Center train times" />
-  <link rel="canonical" href="https://nextmetro.live/station/metro-center/" />
+<link rel="canonical" href="https://nextmetro.live/station/metro-center/" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Metro Center Station — Live Red, Orange, Blue & Silver Arrivals | NextMetro" />

--- a/public/station/metro-center/index.html
+++ b/public/station/metro-center/index.html
@@ -3,13 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Metro Center — Real-Time Metro Arrivals | NextMetro</title>
-  <meta name="description" content="Live train arrivals and real-time predictions for Metro Center transfer station. Red, Orange, Blue, and Silver Line arrivals on dual platform PIDS boards. Track next trains, check elevator status, and calculate fares." />
+  <title>Metro Center Station — Real-Time Arrivals, Transfers & Info | NextMetro</title>
+  <meta name="description" content="Live dual-platform arrivals for Metro Center transfer station in downtown Washington, DC. Red, Orange, Blue, and Silver Line PIDS boards side by side. Fare calculator, elevator status, transfer info, and service alerts." />
+  <meta name="robots" content="index, follow" />
+  <meta name="keywords" content="Metro Center station, DC Metro transfer, Red Line arrivals, Orange Line arrivals, Blue Line arrivals, Silver Line arrivals, downtown DC Metro, WMATA real-time, Metro Center platform, Metro Center train times" />
   <link rel="canonical" href="https://nextmetro.live/station/metro-center/" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Metro Center — Real-Time Metro Arrivals | NextMetro" />
-  <meta property="og:description" content="Live dual-platform arrivals for Metro Center transfer station — Red, Orange, Blue, and Silver Lines." />
+  <meta property="og:title" content="Metro Center Station — Live Red, Orange, Blue & Silver Arrivals | NextMetro" />
+  <meta property="og:description" content="Real-time dual-platform arrivals for Metro Center transfer station in downtown DC. Red, Orange, Blue, and Silver Line PIDS boards, fares, and service alerts." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://nextmetro.live/station/metro-center/" />
   <meta property="og:site_name" content="NextMetro" />
@@ -21,8 +23,8 @@
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Metro Center — Real-Time Metro Arrivals | NextMetro" />
-  <meta name="twitter:description" content="Live dual-platform arrivals for Metro Center transfer station — Red, Orange, Blue, and Silver Lines." />
+  <meta name="twitter:title" content="Metro Center Station — Live Red, Orange, Blue & Silver Arrivals | NextMetro" />
+  <meta name="twitter:description" content="Real-time dual-platform arrivals for Metro Center transfer station in downtown DC. Red, Orange, Blue, and Silver Line PIDS boards, fares, and service alerts." />
   <meta name="twitter:image" content="https://nextmetro.live/images/og/stations/og-station-metro-center.png" />
 
   <!-- Favicon -->
@@ -73,10 +75,25 @@
       "@context": "https://schema.org",
       "@type": "TrainStation",
       "name": "Metro Center",
+      "alternateName": ["Metro Center Station", "Metro Center Transfer Station"],
+      "description": "Metro Center is a major underground transfer station in downtown Washington, DC, serving the Red, Orange, Blue, and Silver Lines. It features two platforms: Platform A for the Red Line and Platform B for the Orange, Blue, and Silver Lines.",
       "url": "https://nextmetro.live/station/metro-center/",
+      "sameAs": "https://www.wmata.com/rider-guide/stations/metro-center.cfm",
+      "image": "https://nextmetro.live/images/og/stations/og-station-metro-center.png",
       "hasMap": "https://wmata.com/schedules/maps/upload/system-map-rail.pdf",
       "isAccessibleForFree": false,
       "publicAccess": true,
+      "smokingAllowed": false,
+      "wheelchair": true,
+      "amenityFeature": [
+        { "@type": "LocationFeatureSpecification", "name": "Elevator", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "Escalator", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "Transfer Between Lines", "value": true }
+      ],
+      "containedInPlace": {
+        "@type": "City",
+        "name": "Washington, DC"
+      },
       "address": {
         "@type": "PostalAddress",
         "streetAddress": "607 13th St NW",

--- a/public/station/metro-center/index.html
+++ b/public/station/metro-center/index.html
@@ -3,27 +3,27 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Brookland-CUA — Real-Time Metro Arrivals | NextMetro</title>
-  <meta name="description" content="Live train arrivals and real-time predictions for Brookland-CUA Metro station on the Red Line. Track next trains, check elevator status, and calculate fares." />
-  <link rel="canonical" href="https://nextmetro.live/station/brookland-cua/" />
+  <title>Metro Center — Real-Time Metro Arrivals | NextMetro</title>
+  <meta name="description" content="Live train arrivals and real-time predictions for Metro Center transfer station. Red, Orange, Blue, and Silver Line arrivals on dual platform PIDS boards. Track next trains, check elevator status, and calculate fares." />
+  <link rel="canonical" href="https://nextmetro.live/station/metro-center/" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Brookland-CUA — Real-Time Metro Arrivals | NextMetro" />
-  <meta property="og:description" content="Live train arrivals and real-time predictions for Brookland-CUA Metro station on the Red Line." />
+  <meta property="og:title" content="Metro Center — Real-Time Metro Arrivals | NextMetro" />
+  <meta property="og:description" content="Live dual-platform arrivals for Metro Center transfer station — Red, Orange, Blue, and Silver Lines." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://nextmetro.live/station/brookland-cua/" />
+  <meta property="og:url" content="https://nextmetro.live/station/metro-center/" />
   <meta property="og:site_name" content="NextMetro" />
   <meta property="og:locale" content="en_US" />
-  <meta property="og:image" content="https://nextmetro.live/images/og/stations/og-station-brookland-cua.png" />
+  <meta property="og:image" content="https://nextmetro.live/images/og/stations/og-station-metro-center.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
-  <meta property="og:image:alt" content="Brookland-CUA Station — Real-Time Metro Arrivals | NextMetro" />
+  <meta property="og:image:alt" content="Metro Center Station — Real-Time Metro Arrivals | NextMetro" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Brookland-CUA — Real-Time Metro Arrivals | NextMetro" />
-  <meta name="twitter:description" content="Live train arrivals and real-time predictions for Brookland-CUA Metro station on the Red Line." />
-  <meta name="twitter:image" content="https://nextmetro.live/images/og/stations/og-station-brookland-cua.png" />
+  <meta name="twitter:title" content="Metro Center — Real-Time Metro Arrivals | NextMetro" />
+  <meta name="twitter:description" content="Live dual-platform arrivals for Metro Center transfer station — Red, Orange, Blue, and Silver Lines." />
+  <meta name="twitter:image" content="https://nextmetro.live/images/og/stations/og-station-metro-center.png" />
 
   <!-- Favicon -->
   <link rel="icon" href="/favicon.ico" sizes="48x48" />
@@ -64,32 +64,31 @@
         {
           "@type": "ListItem",
           "position": 3,
-          "name": "Brookland-CUA",
-          "item": "https://nextmetro.live/station/brookland-cua/"
+          "name": "Metro Center",
+          "item": "https://nextmetro.live/station/metro-center/"
         }
       ]
     },
     {
       "@context": "https://schema.org",
       "@type": "TrainStation",
-      "name": "Brookland-CUA",
-      "alternateName": "Brookland–Catholic University of America",
-      "url": "https://nextmetro.live/station/brookland-cua/",
+      "name": "Metro Center",
+      "url": "https://nextmetro.live/station/metro-center/",
       "hasMap": "https://wmata.com/schedules/maps/upload/system-map-rail.pdf",
       "isAccessibleForFree": false,
       "publicAccess": true,
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "801 Michigan Ave NE",
+        "streetAddress": "607 13th St NW",
         "addressLocality": "Washington",
         "addressRegion": "DC",
-        "postalCode": "20017",
+        "postalCode": "20005",
         "addressCountry": "US"
       },
       "geo": {
         "@type": "GeoCoordinates",
-        "latitude": 38.9331,
-        "longitude": -76.9946
+        "latitude": 38.8983,
+        "longitude": -77.0281
       },
       "openingHoursSpecification": [
         {
@@ -115,6 +114,44 @@
           "dayOfWeek": "Sunday",
           "opens": "07:00",
           "closes": "00:00"
+        }
+      ]
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What Metro lines serve Metro Center station?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metro Center is a transfer station served by the Red, Orange, Blue, and Silver Lines. It has two platforms: Platform A serves the Red Line, and Platform B serves the Orange, Blue, and Silver Lines."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How do I transfer between lines at Metro Center?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metro Center has two separate platforms connected by escalators and elevators within the station. Platform A serves the Red Line (toward Shady Grove and Glenmont), and Platform B serves the Orange, Blue, and Silver Lines. Follow the signs inside the station to transfer between platforms without leaving the fare gates."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What is near Metro Center station?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metro Center is located in the heart of downtown Washington, DC near the White House, National Mall, Smithsonian museums, Capital One Arena, CityCenterDC, and the downtown business district along K Street and Connecticut Avenue."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What are the hours of operation for Metro Center station?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metro Center station is open Monday through Thursday from 5:00 AM to midnight, Friday from 5:00 AM to 1:00 AM, Saturday from 7:00 AM to 1:00 AM, and Sunday from 7:00 AM to midnight."
+          }
         }
       ]
     }
@@ -159,22 +196,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <!-- Hero / Station Selector -->
-  <section class="hero hero--has-image" id="hero">
-    <div class="hero__image" aria-hidden="true">
-      <img src="/images/heroes/brookland-cua.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
-    </div>
+  <!-- Hero / Station Header -->
+  <section class="hero" id="hero">
     <div class="hero-inner">
       <nav class="hero-breadcrumb" aria-label="Breadcrumb">
         <a href="/">Home</a>
         <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
         <a href="/lines/red/">Red Line</a>
         <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <span class="hero-breadcrumb__current">Brookland-CUA</span>
+        <span class="hero-breadcrumb__current">Metro Center</span>
       </nav>
       <span class="hero-label">Station</span>
-      <h1 class="hero-station-name" id="hero-station-name">Brookland-CUA</h1>
-      <p class="hero-station-desc" id="hero-station-desc">Servicing Brookland, Edgewood &amp; Catholic University of America.</p>
+      <h1 class="hero-station-name" id="hero-station-name">Metro Center</h1>
+      <p class="hero-station-desc" id="hero-station-desc">Downtown DC's central hub — Red, Orange, Blue &amp; Silver Lines.</p>
+      <span class="hero-transfer-badge">Transfer Station</span>
 
       <!-- Line Pills -->
       <div class="line-pills" id="line-pills"></div>
@@ -199,18 +234,44 @@
   <main id="main-content" class="main-grid">
     <div class="main-column">
 
-      <!-- PIDS Arrivals Display -->
-      <section class="pids-card animate-in d1">
-        <div class="pids-header" id="pids-header">
-          <span class="pids-header-station" id="pids-header-station">Next Arrivals</span>
-        </div>
-        <div class="pids-screen" id="pids-screen">
-          <div class="pids-scanlines"></div>
-          <div class="pids-content" id="pids-content">
-            <!-- Train rows rendered by JS -->
+      <!-- Dual PIDS Grid — Two platforms side by side -->
+      <div class="pids-grid animate-in d1">
+
+        <!-- Platform A: Red Line -->
+        <section class="pids-card" id="pids-card-a">
+          <div class="pids-header">
+            <div class="line-strip-group">
+              <div class="line-strip" style="background: var(--nm-line-red)"></div>
+            </div>
+            <span class="platform-label">Platform A · Red Line</span>
           </div>
-        </div>
-      </section>
+          <div class="pids-screen">
+            <div class="pids-scanlines"></div>
+            <div class="pids-content" id="pids-content-a">
+              <!-- Platform A train rows rendered by JS -->
+            </div>
+          </div>
+        </section>
+
+        <!-- Platform B: Orange / Blue / Silver -->
+        <section class="pids-card" id="pids-card-b">
+          <div class="pids-header">
+            <div class="line-strip-group">
+              <div class="line-strip" style="background: var(--nm-line-orange)"></div>
+              <div class="line-strip" style="background: var(--nm-line-blue)"></div>
+              <div class="line-strip" style="background: var(--nm-line-silver)"></div>
+            </div>
+            <span class="platform-label">Platform B · Or / Bl / Sv</span>
+          </div>
+          <div class="pids-screen">
+            <div class="pids-scanlines"></div>
+            <div class="pids-content" id="pids-content-b">
+              <!-- Platform B train rows rendered by JS -->
+            </div>
+          </div>
+        </section>
+
+      </div>
 
       <!-- Last Updated -->
       <div class="last-updated" id="last-updated" style="display:none;">
@@ -231,14 +292,21 @@
               <i class="ri-map-pin-line" aria-hidden="true"></i>
             </span>
             <span class="station-info-label">Address</span>
-            <span class="station-info-value">801 Michigan Ave NE, Washington, DC 20017</span>
+            <span class="station-info-value">607 13th St NW, Washington, DC 20005</span>
           </div>
           <div class="station-info-row">
             <span class="station-info-icon">
               <i class="ri-indeterminate-circle-line" aria-hidden="true"></i>
             </span>
             <span class="station-info-label">Station Type</span>
-            <span class="station-info-value">Ground Level</span>
+            <span class="station-info-value">Underground · Transfer Station</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon">
+              <i class="ri-door-open-line" aria-hidden="true"></i>
+            </span>
+            <span class="station-info-label">Entrances</span>
+            <span class="station-info-value">12th &amp; G St NW, 13th &amp; G St NW, 12th &amp; F St NW</span>
           </div>
           <div class="station-info-row">
             <span class="station-info-icon">
@@ -261,18 +329,25 @@
           </div>
           <div class="station-info-row">
             <span class="station-info-icon">
+              <i class="ri-map-2-fill" aria-hidden="true"></i>
+            </span>
+            <span class="station-info-label">Neighborhood</span>
+            <span class="station-info-value">Downtown DC, Penn Quarter</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon">
               <i class="ri-bus-fill" aria-hidden="true"></i>
             </span>
             <span class="station-info-label">Bus Lines</span>
-            <span class="station-info-value">H2, H3, H4, H8, H9</span>
+            <span class="station-info-value">D6, 42, 54, P6, S2, S4, X2</span>
           </div>
         </div>
         <div class="station-info-actions">
-          <a href="https://www.google.com/maps/dir/?api=1&destination=38.9331,-76.9946" class="station-info-link" target="_blank" rel="noopener noreferrer">
+          <a href="https://www.google.com/maps/dir/?api=1&destination=38.8983,-77.0281" class="station-info-link" target="_blank" rel="noopener noreferrer">
             <i class="ri-direction-line" aria-hidden="true"></i>
             Directions
           </a>
-          <a href="https://www.wmata.com/rider-guide/stations/brookland.cfm" class="station-info-link" target="_blank" rel="noopener noreferrer">
+          <a href="https://www.wmata.com/rider-guide/stations/metro-center.cfm" class="station-info-link" target="_blank" rel="noopener noreferrer">
             <i class="ri-external-link-line" aria-hidden="true"></i>
             WMATA Station Page
           </a>
@@ -288,7 +363,7 @@
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
-              <span class="fare-station-name" id="fare-from-name">Brookland-CUA</span>
+              <span class="fare-station-name" id="fare-from-name">Metro Center</span>
             </div>
             <div class="fare-arrow">
               <i class="ri-arrow-right-box-fill" aria-hidden="true"></i>
@@ -322,34 +397,86 @@
         </div>
       </section>
 
+      <!-- Station FAQ -->
+      <section class="station-faq animate-in d5">
+        <h2 class="station-faq-title">Frequently Asked Questions</h2>
+        <div class="station-faq-list">
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What Metro lines serve Metro Center station?</summary>
+            <p class="station-faq-answer">Metro Center is a transfer station served by the Red, Orange, Blue, and Silver Lines. It has two platforms: Platform A serves the Red Line, and Platform B serves the Orange, Blue, and Silver Lines.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">How do I transfer between lines at Metro Center?</summary>
+            <p class="station-faq-answer">Metro Center has two separate platforms connected by escalators and elevators within the station. Platform A serves the Red Line (toward Shady Grove and Glenmont), and Platform B serves the Orange, Blue, and Silver Lines. Follow the signs inside the station to transfer between platforms without leaving the fare gates.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What is near Metro Center station?</summary>
+            <p class="station-faq-answer">Metro Center is located in the heart of downtown Washington, DC near the White House, National Mall, Smithsonian museums, Capital One Arena, CityCenterDC, and the downtown business district along K Street and Connecticut Avenue.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What are the hours of operation for Metro Center station?</summary>
+            <p class="station-faq-answer">Metro Center station is open Monday through Thursday from 5:00 AM to midnight, Friday from 5:00 AM to 1:00 AM, Saturday from 7:00 AM to 1:00 AM, and Sunday from 7:00 AM to midnight.</p>
+          </details>
+        </div>
+      </section>
+
     </div>
 
     <!-- Sidebar -->
     <aside class="sidebar">
 
-      <!-- Adjacent Stations -->
+      <!-- Adjacent Stations — Red Line -->
       <section class="adjacent-card animate-in d2">
         <div class="adjacent-header">
           <h2 class="adjacent-title">Adjacent Stations</h2>
           <span class="adjacent-line-badge adjacent-line-badge--red">Red Line</span>
         </div>
         <div class="adjacent-body">
-          <a href="/station/rhode-island-ave/" class="adjacent-station adjacent-station--prev">
+          <a href="/station/farragut-north/" class="adjacent-station adjacent-station--prev">
             <span class="adjacent-direction">
               <i class="ri-arrow-left-s-line" aria-hidden="true"></i>
               Toward Shady Grove
             </span>
-            <span class="adjacent-name">Rhode Island Ave-Brentwood</span>
+            <span class="adjacent-name">Farragut North</span>
           </a>
           <div class="adjacent-divider">
             <span class="adjacent-current-dot"></span>
           </div>
-          <a href="/station/fort-totten/" class="adjacent-station adjacent-station--next">
+          <a href="/station/gallery-place/" class="adjacent-station adjacent-station--next">
             <span class="adjacent-direction">
               Toward Glenmont
               <i class="ri-arrow-right-s-line" aria-hidden="true"></i>
             </span>
-            <span class="adjacent-name">Fort Totten</span>
+            <span class="adjacent-name">Gallery Pl-Chinatown</span>
+          </a>
+        </div>
+      </section>
+
+      <!-- Adjacent Stations — Orange / Blue / Silver Lines -->
+      <section class="adjacent-card animate-in d2">
+        <div class="adjacent-header">
+          <h2 class="adjacent-title">Adjacent Stations</h2>
+          <span class="adjacent-line-badge adjacent-line-badge--orange">Or</span>
+          <span class="adjacent-line-badge adjacent-line-badge--blue">Bl</span>
+          <span class="adjacent-line-badge adjacent-line-badge--silver">Sv</span>
+        </div>
+        <div class="adjacent-body">
+          <a href="/station/farragut-west/" class="adjacent-station adjacent-station--prev">
+            <span class="adjacent-direction">
+              <i class="ri-arrow-left-s-line" aria-hidden="true"></i>
+              Toward Vienna / Largo
+            </span>
+            <span class="adjacent-name">Farragut West</span>
+          </a>
+          <div class="adjacent-divider">
+            <span class="adjacent-current-dot"></span>
+          </div>
+          <a href="/station/federal-triangle/" class="adjacent-station adjacent-station--next">
+            <span class="adjacent-direction">
+              Toward Franconia / New Carrollton
+              <i class="ri-arrow-right-s-line" aria-hidden="true"></i>
+            </span>
+            <span class="adjacent-name">Federal Triangle</span>
           </a>
         </div>
       </section>
@@ -485,8 +612,23 @@
   </footer>
   <script src="/js/nav.js"></script>
   <script>
-  // Brookland-CUA station-specific config
-  const STATION_CODE = 'B05';
+  // Metro Center is a transfer station — use dedicated dual-PIDS logic
+  const STATION_CODE = 'A01';
+  const IS_TRANSFER_STATION = true;
+  const TRANSFER_PLATFORMS = [
+    {
+      label: 'Platform A \u00B7 Red Line',
+      lines: ['RD'],
+      wmataCodes: ['A01'],
+      contentEl: 'pids-content-a'
+    },
+    {
+      label: 'Platform B \u00B7 Or / Bl / Sv',
+      lines: ['OR', 'BL', 'SV'],
+      wmataCodes: ['C01'],
+      contentEl: 'pids-content-b'
+    }
+  ];
   </script>
   <script src="/js/app.js"></script>
 </body>

--- a/public/station/potomac-yard/index.html
+++ b/public/station/potomac-yard/index.html
@@ -6,8 +6,7 @@
   <title>Potomac Yard Station — Real-Time Arrivals, Fares & Info | NextMetro</title>
   <meta name="description" content="Live train arrivals for Potomac Yard Metro station on the Blue and Yellow Lines in Alexandria, VA. Real-time PIDS board, fare calculator, elevator status, and service alerts for WMATA's newest station." />
   <meta name="robots" content="index, follow" />
-  <meta name="keywords" content="Potomac Yard Metro station, Blue Line arrivals, Yellow Line arrivals, Alexandria Metro, WMATA real-time, Potomac Yard train times, new Metro station Alexandria, DC Metro near Potomac Yard" />
-  <link rel="canonical" href="https://nextmetro.live/station/potomac-yard/" />
+<link rel="canonical" href="https://nextmetro.live/station/potomac-yard/" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Potomac Yard Station — Live Blue & Yellow Line Arrivals | NextMetro" />

--- a/public/station/potomac-yard/index.html
+++ b/public/station/potomac-yard/index.html
@@ -3,13 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Potomac Yard — Real-Time Metro Arrivals | NextMetro</title>
-  <meta name="description" content="Live train arrivals and real-time predictions for Potomac Yard Metro station on the Blue and Yellow Lines. Track next trains, check elevator status, and calculate fares." />
+  <title>Potomac Yard Station — Real-Time Arrivals, Fares & Info | NextMetro</title>
+  <meta name="description" content="Live train arrivals for Potomac Yard Metro station on the Blue and Yellow Lines in Alexandria, VA. Real-time PIDS board, fare calculator, elevator status, and service alerts for WMATA's newest station." />
+  <meta name="robots" content="index, follow" />
+  <meta name="keywords" content="Potomac Yard Metro station, Blue Line arrivals, Yellow Line arrivals, Alexandria Metro, WMATA real-time, Potomac Yard train times, new Metro station Alexandria, DC Metro near Potomac Yard" />
   <link rel="canonical" href="https://nextmetro.live/station/potomac-yard/" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Potomac Yard — Real-Time Metro Arrivals | NextMetro" />
-  <meta property="og:description" content="Live train arrivals and real-time predictions for Potomac Yard Metro station on the Blue and Yellow Lines." />
+  <meta property="og:title" content="Potomac Yard Station — Live Blue & Yellow Line Arrivals | NextMetro" />
+  <meta property="og:description" content="Real-time Blue and Yellow Line arrivals for Potomac Yard Metro station in Alexandria, VA. Live PIDS board, fares, elevator status, and service alerts." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://nextmetro.live/station/potomac-yard/" />
   <meta property="og:site_name" content="NextMetro" />
@@ -21,8 +23,8 @@
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Potomac Yard — Real-Time Metro Arrivals | NextMetro" />
-  <meta name="twitter:description" content="Live train arrivals and real-time predictions for Potomac Yard Metro station on the Blue and Yellow Lines." />
+  <meta name="twitter:title" content="Potomac Yard Station — Live Blue & Yellow Line Arrivals | NextMetro" />
+  <meta name="twitter:description" content="Real-time Blue and Yellow Line arrivals for Potomac Yard Metro station in Alexandria, VA. Live PIDS board, fares, elevator status, and service alerts." />
   <meta name="twitter:image" content="https://nextmetro.live/images/og/stations/og-station-potomac-yard.png" />
 
   <!-- Favicon -->
@@ -73,10 +75,29 @@
       "@context": "https://schema.org",
       "@type": "TrainStation",
       "name": "Potomac Yard",
+      "alternateName": ["Potomac Yard Metro Station", "Potomac Yard-VT Station"],
+      "description": "Potomac Yard is WMATA's newest Metrorail station, opened May 2023. Located on the Blue and Yellow Lines in Alexandria, VA, it serves the Potomac Yard and North Alexandria neighborhoods.",
       "url": "https://nextmetro.live/station/potomac-yard/",
+      "sameAs": "https://www.wmata.com/rider-guide/stations/potomac-yard.cfm",
+      "image": "https://nextmetro.live/images/og/stations/og-station-potomac-yard.png",
       "hasMap": "https://wmata.com/schedules/maps/upload/system-map-rail.pdf",
       "isAccessibleForFree": false,
       "publicAccess": true,
+      "smokingAllowed": false,
+      "wheelchair": true,
+      "amenityFeature": [
+        { "@type": "LocationFeatureSpecification", "name": "Elevator", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "Escalator", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "Bicycle Parking", "value": true }
+      ],
+      "containedInPlace": {
+        "@type": "City",
+        "name": "Alexandria",
+        "containedInPlace": {
+          "@type": "State",
+          "name": "Virginia"
+        }
+      },
       "address": {
         "@type": "PostalAddress",
         "streetAddress": "3501 Potomac Ave",

--- a/public/station/potomac-yard/index.html
+++ b/public/station/potomac-yard/index.html
@@ -3,27 +3,27 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Brookland-CUA — Real-Time Metro Arrivals | NextMetro</title>
-  <meta name="description" content="Live train arrivals and real-time predictions for Brookland-CUA Metro station on the Red Line. Track next trains, check elevator status, and calculate fares." />
-  <link rel="canonical" href="https://nextmetro.live/station/brookland-cua/" />
+  <title>Potomac Yard — Real-Time Metro Arrivals | NextMetro</title>
+  <meta name="description" content="Live train arrivals and real-time predictions for Potomac Yard Metro station on the Blue and Yellow Lines. Track next trains, check elevator status, and calculate fares." />
+  <link rel="canonical" href="https://nextmetro.live/station/potomac-yard/" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Brookland-CUA — Real-Time Metro Arrivals | NextMetro" />
-  <meta property="og:description" content="Live train arrivals and real-time predictions for Brookland-CUA Metro station on the Red Line." />
+  <meta property="og:title" content="Potomac Yard — Real-Time Metro Arrivals | NextMetro" />
+  <meta property="og:description" content="Live train arrivals and real-time predictions for Potomac Yard Metro station on the Blue and Yellow Lines." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://nextmetro.live/station/brookland-cua/" />
+  <meta property="og:url" content="https://nextmetro.live/station/potomac-yard/" />
   <meta property="og:site_name" content="NextMetro" />
   <meta property="og:locale" content="en_US" />
-  <meta property="og:image" content="https://nextmetro.live/images/og/stations/og-station-brookland-cua.png" />
+  <meta property="og:image" content="https://nextmetro.live/images/og/stations/og-station-potomac-yard.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
-  <meta property="og:image:alt" content="Brookland-CUA Station — Real-Time Metro Arrivals | NextMetro" />
+  <meta property="og:image:alt" content="Potomac Yard Station — Real-Time Metro Arrivals | NextMetro" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Brookland-CUA — Real-Time Metro Arrivals | NextMetro" />
-  <meta name="twitter:description" content="Live train arrivals and real-time predictions for Brookland-CUA Metro station on the Red Line." />
-  <meta name="twitter:image" content="https://nextmetro.live/images/og/stations/og-station-brookland-cua.png" />
+  <meta name="twitter:title" content="Potomac Yard — Real-Time Metro Arrivals | NextMetro" />
+  <meta name="twitter:description" content="Live train arrivals and real-time predictions for Potomac Yard Metro station on the Blue and Yellow Lines." />
+  <meta name="twitter:image" content="https://nextmetro.live/images/og/stations/og-station-potomac-yard.png" />
 
   <!-- Favicon -->
   <link rel="icon" href="/favicon.ico" sizes="48x48" />
@@ -58,38 +58,37 @@
         {
           "@type": "ListItem",
           "position": 2,
-          "name": "Red Line",
-          "item": "https://nextmetro.live/lines/red/"
+          "name": "Blue Line",
+          "item": "https://nextmetro.live/lines/blue/"
         },
         {
           "@type": "ListItem",
           "position": 3,
-          "name": "Brookland-CUA",
-          "item": "https://nextmetro.live/station/brookland-cua/"
+          "name": "Potomac Yard",
+          "item": "https://nextmetro.live/station/potomac-yard/"
         }
       ]
     },
     {
       "@context": "https://schema.org",
       "@type": "TrainStation",
-      "name": "Brookland-CUA",
-      "alternateName": "Brookland–Catholic University of America",
-      "url": "https://nextmetro.live/station/brookland-cua/",
+      "name": "Potomac Yard",
+      "url": "https://nextmetro.live/station/potomac-yard/",
       "hasMap": "https://wmata.com/schedules/maps/upload/system-map-rail.pdf",
       "isAccessibleForFree": false,
       "publicAccess": true,
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "801 Michigan Ave NE",
-        "addressLocality": "Washington",
-        "addressRegion": "DC",
-        "postalCode": "20017",
+        "streetAddress": "3501 Potomac Ave",
+        "addressLocality": "Alexandria",
+        "addressRegion": "VA",
+        "postalCode": "22305",
         "addressCountry": "US"
       },
       "geo": {
         "@type": "GeoCoordinates",
-        "latitude": 38.9331,
-        "longitude": -76.9946
+        "latitude": 38.8430,
+        "longitude": -77.0513
       },
       "openingHoursSpecification": [
         {
@@ -115,6 +114,44 @@
           "dayOfWeek": "Sunday",
           "opens": "07:00",
           "closes": "00:00"
+        }
+      ]
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What Metro lines serve Potomac Yard station?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Potomac Yard is served by the Blue Line and the Yellow Line. It provides direct access to destinations in Alexandria, Arlington, and downtown Washington, DC."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "When did Potomac Yard station open?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Potomac Yard station opened on May 19, 2023, making it the newest station in the WMATA Metrorail system. It is located between Ronald Reagan Washington National Airport and Braddock Road stations."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does Potomac Yard station have parking?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Potomac Yard station does not have a WMATA-operated parking garage. The station is designed as a transit-oriented development hub with pedestrian and bicycle access prioritized."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What are the hours of operation for Potomac Yard station?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Potomac Yard station is open Monday through Thursday from 5:00 AM to midnight, Friday from 5:00 AM to 1:00 AM, Saturday from 7:00 AM to 1:00 AM, and Sunday from 7:00 AM to midnight."
+          }
         }
       ]
     }
@@ -159,22 +196,22 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <!-- Hero / Station Selector -->
+  <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
-      <img src="/images/heroes/brookland-cua.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
+      <img src="/images/potomac-yard-vt.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
     </div>
     <div class="hero-inner">
       <nav class="hero-breadcrumb" aria-label="Breadcrumb">
         <a href="/">Home</a>
         <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <a href="/lines/red/">Red Line</a>
+        <a href="/lines/blue/">Blue Line</a>
         <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <span class="hero-breadcrumb__current">Brookland-CUA</span>
+        <span class="hero-breadcrumb__current">Potomac Yard</span>
       </nav>
       <span class="hero-label">Station</span>
-      <h1 class="hero-station-name" id="hero-station-name">Brookland-CUA</h1>
-      <p class="hero-station-desc" id="hero-station-desc">Servicing Brookland, Edgewood &amp; Catholic University of America.</p>
+      <h1 class="hero-station-name" id="hero-station-name">Potomac Yard</h1>
+      <p class="hero-station-desc" id="hero-station-desc">WMATA's newest station, servicing Potomac Yard &amp; North Alexandria.</p>
 
       <!-- Line Pills -->
       <div class="line-pills" id="line-pills"></div>
@@ -231,14 +268,21 @@
               <i class="ri-map-pin-line" aria-hidden="true"></i>
             </span>
             <span class="station-info-label">Address</span>
-            <span class="station-info-value">801 Michigan Ave NE, Washington, DC 20017</span>
+            <span class="station-info-value">3501 Potomac Ave, Alexandria, VA 22305</span>
           </div>
           <div class="station-info-row">
             <span class="station-info-icon">
               <i class="ri-indeterminate-circle-line" aria-hidden="true"></i>
             </span>
             <span class="station-info-label">Station Type</span>
-            <span class="station-info-value">Ground Level</span>
+            <span class="station-info-value">Elevated</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon">
+              <i class="ri-calendar-line" aria-hidden="true"></i>
+            </span>
+            <span class="station-info-label">Opened</span>
+            <span class="station-info-value">May 19, 2023</span>
           </div>
           <div class="station-info-row">
             <span class="station-info-icon">
@@ -264,15 +308,15 @@
               <i class="ri-bus-fill" aria-hidden="true"></i>
             </span>
             <span class="station-info-label">Bus Lines</span>
-            <span class="station-info-value">H2, H3, H4, H8, H9</span>
+            <span class="station-info-value">DASH AT3, AT5, AT9</span>
           </div>
         </div>
         <div class="station-info-actions">
-          <a href="https://www.google.com/maps/dir/?api=1&destination=38.9331,-76.9946" class="station-info-link" target="_blank" rel="noopener noreferrer">
+          <a href="https://www.google.com/maps/dir/?api=1&destination=38.8430,-77.0513" class="station-info-link" target="_blank" rel="noopener noreferrer">
             <i class="ri-direction-line" aria-hidden="true"></i>
             Directions
           </a>
-          <a href="https://www.wmata.com/rider-guide/stations/brookland.cfm" class="station-info-link" target="_blank" rel="noopener noreferrer">
+          <a href="https://www.wmata.com/rider-guide/stations/potomac-yard.cfm" class="station-info-link" target="_blank" rel="noopener noreferrer">
             <i class="ri-external-link-line" aria-hidden="true"></i>
             WMATA Station Page
           </a>
@@ -288,7 +332,7 @@
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
-              <span class="fare-station-name" id="fare-from-name">Brookland-CUA</span>
+              <span class="fare-station-name" id="fare-from-name">Potomac Yard</span>
             </div>
             <div class="fare-arrow">
               <i class="ri-arrow-right-box-fill" aria-hidden="true"></i>
@@ -322,6 +366,29 @@
         </div>
       </section>
 
+      <!-- Station FAQ -->
+      <section class="station-faq animate-in d5">
+        <h2 class="station-faq-title">Frequently Asked Questions</h2>
+        <div class="station-faq-list">
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What Metro lines serve Potomac Yard station?</summary>
+            <p class="station-faq-answer">Potomac Yard is served by the Blue Line and the Yellow Line. It provides direct access to destinations in Alexandria, Arlington, and downtown Washington, DC.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">When did Potomac Yard station open?</summary>
+            <p class="station-faq-answer">Potomac Yard station opened on May 19, 2023, making it the newest station in the WMATA Metrorail system. It is located between Ronald Reagan Washington National Airport and Braddock Road stations.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">Does Potomac Yard station have parking?</summary>
+            <p class="station-faq-answer">Potomac Yard station does not have a WMATA-operated parking garage. The station is designed as a transit-oriented development hub with pedestrian and bicycle access prioritized.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What are the hours of operation for Potomac Yard station?</summary>
+            <p class="station-faq-answer">Potomac Yard station is open Monday through Thursday from 5:00 AM to midnight, Friday from 5:00 AM to 1:00 AM, Saturday from 7:00 AM to 1:00 AM, and Sunday from 7:00 AM to midnight.</p>
+          </details>
+        </div>
+      </section>
+
     </div>
 
     <!-- Sidebar -->
@@ -331,25 +398,26 @@
       <section class="adjacent-card animate-in d2">
         <div class="adjacent-header">
           <h2 class="adjacent-title">Adjacent Stations</h2>
-          <span class="adjacent-line-badge adjacent-line-badge--red">Red Line</span>
+          <span class="adjacent-line-badge adjacent-line-badge--blue">Blue Line</span>
+          <span class="adjacent-line-badge adjacent-line-badge--yellow">Yellow Line</span>
         </div>
         <div class="adjacent-body">
-          <a href="/station/rhode-island-ave/" class="adjacent-station adjacent-station--prev">
+          <a href="/station/ronald-reagan-washington-national-airport/" class="adjacent-station adjacent-station--prev">
             <span class="adjacent-direction">
               <i class="ri-arrow-left-s-line" aria-hidden="true"></i>
-              Toward Shady Grove
+              Toward Franconia / Mt Vernon Sq
             </span>
-            <span class="adjacent-name">Rhode Island Ave-Brentwood</span>
+            <span class="adjacent-name">Ronald Reagan Washington National Airport</span>
           </a>
           <div class="adjacent-divider">
             <span class="adjacent-current-dot"></span>
           </div>
-          <a href="/station/fort-totten/" class="adjacent-station adjacent-station--next">
+          <a href="/station/braddock-road/" class="adjacent-station adjacent-station--next">
             <span class="adjacent-direction">
-              Toward Glenmont
+              Toward Huntington / Greenbelt
               <i class="ri-arrow-right-s-line" aria-hidden="true"></i>
             </span>
-            <span class="adjacent-name">Fort Totten</span>
+            <span class="adjacent-name">Braddock Road</span>
           </a>
         </div>
       </section>
@@ -485,8 +553,8 @@
   </footer>
   <script src="/js/nav.js"></script>
   <script>
-  // Brookland-CUA station-specific config
-  const STATION_CODE = 'B05';
+  // Potomac Yard station-specific config
+  const STATION_CODE = 'C11';
   </script>
   <script src="/js/app.js"></script>
 </body>

--- a/public/station/union-station/index.html
+++ b/public/station/union-station/index.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Union Station — Real-Time Arrivals, Fares & Info | NextMetro</title>
+  <meta name="description" content="Live train arrivals for Union Station Metro on the Red Line in Washington, DC. Real-time PIDS board, fare calculator, elevator status, and service alerts. Connect to Amtrak, MARC, and VRE." />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://nextmetro.live/station/union-station/" />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Union Station — Live Red Line Arrivals | NextMetro" />
+  <meta property="og:description" content="Real-time Red Line arrivals for Union Station Metro. Live PIDS board, fares, elevator status, Amtrak/MARC/VRE connections." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://nextmetro.live/station/union-station/" />
+  <meta property="og:site_name" content="NextMetro" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://nextmetro.live/images/og/stations/og-station-union-station.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="Union Station — Real-Time Metro Arrivals | NextMetro" />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Union Station — Live Red Line Arrivals | NextMetro" />
+  <meta name="twitter:description" content="Real-time Red Line arrivals for Union Station Metro. Live PIDS board, fares, elevator status, Amtrak/MARC/VRE connections." />
+  <meta name="twitter:image" content="https://nextmetro.live/images/og/stations/og-station-union-station.png" />
+
+  <!-- Favicon -->
+  <link rel="icon" href="/favicon.ico" sizes="48x48" />
+  <link rel="icon" href="/images/icons/nm-mark.svg" type="image/svg+xml" />
+  <link rel="icon" href="/images/icons/favicon-32x32.png" sizes="32x32" type="image/png" />
+  <link rel="icon" href="/images/icons/favicon-16x16.png" sizes="16x16" type="image/png" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <meta name="theme-color" content="#0A0A0A" />
+
+  <link rel="stylesheet" href="/css/styles.css" />
+  <link rel="stylesheet" href="/css/nav.css" />
+  <link rel="stylesheet" href="/css/footer.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/remixicon@4.6.0/fonts/remixicon.css" rel="stylesheet" />
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  [
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "NextMetro", "item": "https://nextmetro.live/" },
+        { "@type": "ListItem", "position": 2, "name": "Red Line", "item": "https://nextmetro.live/lines/red/" },
+        { "@type": "ListItem", "position": 3, "name": "Union Station", "item": "https://nextmetro.live/station/union-station/" }
+      ]
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "TrainStation",
+      "name": "Union Station",
+      "alternateName": ["Union Station Metro", "Washington Union Station Metro"],
+      "description": "Union Station is an underground Metrorail station on the Red Line in Washington, DC. It is located beneath the historic Union Station building and provides connections to Amtrak, MARC commuter rail, VRE commuter rail, and DC Streetcar.",
+      "url": "https://nextmetro.live/station/union-station/",
+      "sameAs": "https://www.wmata.com/rider-guide/stations/union-station.cfm",
+      "image": "https://nextmetro.live/images/og/stations/og-station-union-station.png",
+      "hasMap": "https://wmata.com/schedules/maps/upload/system-map-rail.pdf",
+      "isAccessibleForFree": false,
+      "publicAccess": true,
+      "smokingAllowed": false,
+      "wheelchair": true,
+      "amenityFeature": [
+        { "@type": "LocationFeatureSpecification", "name": "Elevator", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "Escalator", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "Bicycle Parking", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "Amtrak Connection", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "MARC Connection", "value": true },
+        { "@type": "LocationFeatureSpecification", "name": "VRE Connection", "value": true }
+      ],
+      "containedInPlace": { "@type": "City", "name": "Washington, DC" },
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "50 Massachusetts Ave NE",
+        "addressLocality": "Washington",
+        "addressRegion": "DC",
+        "postalCode": "20002",
+        "addressCountry": "US"
+      },
+      "geo": { "@type": "GeoCoordinates", "latitude": 38.8978, "longitude": -77.0069 },
+      "openingHoursSpecification": [
+        { "@type": "OpeningHoursSpecification", "dayOfWeek": ["Monday","Tuesday","Wednesday","Thursday"], "opens": "05:00", "closes": "00:00" },
+        { "@type": "OpeningHoursSpecification", "dayOfWeek": "Friday", "opens": "05:00", "closes": "01:00" },
+        { "@type": "OpeningHoursSpecification", "dayOfWeek": "Saturday", "opens": "07:00", "closes": "01:00" },
+        { "@type": "OpeningHoursSpecification", "dayOfWeek": "Sunday", "opens": "07:00", "closes": "00:00" }
+      ]
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What Metro line serves Union Station?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Union Station is served by the Red Line, running between Shady Grove and Glenmont. It is located between Judiciary Square and NoMa-Gallaudet U stations." }
+        },
+        {
+          "@type": "Question",
+          "name": "Can I connect to Amtrak, MARC, or VRE at Union Station?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Yes. Union Station is a major transportation hub with connections to Amtrak (nationwide rail), MARC commuter rail (Maryland), VRE commuter rail (Virginia), and the DC Streetcar (H Street line). The Metro station is located beneath the main Union Station building." }
+        },
+        {
+          "@type": "Question",
+          "name": "Does Union Station Metro have parking?",
+          "acceptedAnswer": { "@type": "Answer", "text": "The Metro station itself does not have a WMATA parking garage. However, Union Station has a large multi-level parking garage operated separately, accessible from H Street NE." }
+        },
+        {
+          "@type": "Question",
+          "name": "What are the hours of operation for Union Station Metro?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Union Station Metro is open Monday through Thursday from 5:00 AM to midnight, Friday from 5:00 AM to 1:00 AM, Saturday from 7:00 AM to 1:00 AM, and Sunday from 7:00 AM to midnight. Note: the Union Station building itself may have different hours." }
+        },
+        {
+          "@type": "Question",
+          "name": "What is near Union Station Metro?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Union Station Metro is located beneath the historic Union Station building in the NoMa/Capitol Hill area. Nearby landmarks include the U.S. Capitol, Senate office buildings, the National Postal Museum, and Columbus Circle. The station is a short walk to the Capitol Hill neighborhood." }
+        }
+      ]
+    }
+  ]
+  </script>
+</head>
+<body>
+
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- NextMetro Site Nav -->
+  <nav class="nm-nav" aria-label="Site navigation">
+    <div class="nm-nav__strip" aria-hidden="true">
+      <span></span><span></span><span></span><span></span><span></span><span></span>
+    </div>
+    <a href="/" class="nm-nav__logo" aria-label="NextMetro home">
+      <span class="nm-nav__logo-next">NEXT</span>
+      <span class="nm-nav__logo-divider" aria-hidden="true"></span>
+      <span class="nm-nav__logo-metro">METRO</span>
+    </a>
+    <div class="nm-nav__links">
+      <a href="/alerts" class="nm-nav__link">Alerts</a>
+      <a href="https://wmata.com/schedules/maps/upload/system-map-rail.pdf" class="nm-nav__link" target="_blank" rel="noopener noreferrer" title="System Map (PDF, opens in new tab)" aria-label="System Map (PDF, opens in new tab)">Map</a>
+      <a href="/fares" class="nm-nav__link">Fares</a>
+      <a href="/hours" class="nm-nav__link">Hours</a>
+    </div>
+    <button class="nm-nav__hamburger" id="navbar-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-menu">
+      <span></span><span></span><span></span>
+    </button>
+  </nav>
+  <div class="nm-mobile-menu" id="mobile-menu">
+    <a href="/alerts" class="mobile-menu-link">Alerts</a>
+    <a href="https://wmata.com/schedules/maps/upload/system-map-rail.pdf" class="mobile-menu-link" target="_blank" rel="noopener noreferrer" title="System Map (PDF, opens in new tab)" aria-label="System Map (PDF, opens in new tab)">Map</a>
+    <a href="/fares" class="mobile-menu-link">Fares</a>
+    <a href="/hours" class="mobile-menu-link">Hours</a>
+  </div>
+
+  <!-- Hero / Station Header -->
+  <section class="hero hero--has-image" id="hero">
+    <div class="hero__image" aria-hidden="true">
+      <img src="/images/union-station.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
+    </div>
+    <div class="hero-inner">
+      <nav class="hero-breadcrumb" aria-label="Breadcrumb">
+        <a href="/">Home</a>
+        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
+        <a href="/lines/red/">Red Line</a>
+        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
+        <span class="hero-breadcrumb__current">Union Station</span>
+      </nav>
+      <span class="hero-label">Station</span>
+      <h1 class="hero-station-name" id="hero-station-name">Union Station</h1>
+      <p class="hero-station-desc" id="hero-station-desc">Capitol Hill's transit hub — Amtrak, MARC, VRE &amp; Metro Red Line.</p>
+
+      <!-- Line Pills -->
+      <div class="line-pills" id="line-pills"></div>
+    </div>
+  </section>
+
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input type="text" id="station-input" class="station-search__input" placeholder="Search stations..." autocomplete="off" aria-label="Search for a Metro station" />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
+  <!-- Main Content -->
+  <main id="main-content" class="main-grid">
+    <div class="main-column">
+
+      <!-- PIDS Arrivals Display -->
+      <section class="pids-card animate-in d1">
+        <div class="pids-header" id="pids-header">
+          <span class="pids-header-station" id="pids-header-station">Next Arrivals</span>
+        </div>
+        <div class="pids-screen" id="pids-screen">
+          <div class="pids-scanlines"></div>
+          <div class="pids-content" id="pids-content"></div>
+        </div>
+      </section>
+
+      <!-- Last Updated -->
+      <div class="last-updated" id="last-updated" style="display:none;">
+        <span id="updated-time"></span>
+        <button class="refresh-btn" id="refresh-btn" aria-label="Refresh train data">
+          <i class="ri-refresh-line" aria-hidden="true"></i>
+        </button>
+      </div>
+
+      <!-- Station Info -->
+      <section class="station-info-card animate-in d3">
+        <div class="station-info-header">
+          <h2 class="station-info-title">Station Information</h2>
+        </div>
+        <div class="station-info-body">
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-map-pin-line" aria-hidden="true"></i></span>
+            <span class="station-info-label">Address</span>
+            <span class="station-info-value">50 Massachusetts Ave NE, Washington, DC 20002</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-indeterminate-circle-line" aria-hidden="true"></i></span>
+            <span class="station-info-label">Station Type</span>
+            <span class="station-info-value">Underground</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-train-fill" aria-hidden="true"></i></span>
+            <span class="station-info-label">Rail Connections</span>
+            <span class="station-info-value">Amtrak, MARC, VRE, DC Streetcar</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-parking-box-line" aria-hidden="true"></i></span>
+            <span class="station-info-label">Parking</span>
+            <span class="station-info-value">Union Station garage (separate operator)</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-time-fill" aria-hidden="true"></i></span>
+            <span class="station-info-label">Hours</span>
+            <span class="station-info-value station-info-value--hours">
+              <span>Mon–Thu: 5:00 AM – 12:00 AM</span>
+              <span>Fri: 5:00 AM – 1:00 AM</span>
+              <span>Sat: 7:00 AM – 1:00 AM</span>
+              <span>Sun: 7:00 AM – 12:00 AM</span>
+            </span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-map-2-fill" aria-hidden="true"></i></span>
+            <span class="station-info-label">Neighborhood</span>
+            <span class="station-info-value">NoMa, Capitol Hill</span>
+          </div>
+          <div class="station-info-row">
+            <span class="station-info-icon"><i class="ri-bus-fill" aria-hidden="true"></i></span>
+            <span class="station-info-label">Bus Lines</span>
+            <span class="station-info-value">80, D6, X2, X8, DC Circulator</span>
+          </div>
+        </div>
+        <div class="station-info-actions">
+          <a href="https://www.google.com/maps/dir/?api=1&destination=38.8978,-77.0069" class="station-info-link" target="_blank" rel="noopener noreferrer">
+            <i class="ri-direction-line" aria-hidden="true"></i> Directions
+          </a>
+          <a href="https://www.wmata.com/rider-guide/stations/union-station.cfm" class="station-info-link" target="_blank" rel="noopener noreferrer">
+            <i class="ri-external-link-line" aria-hidden="true"></i> WMATA Station Page
+          </a>
+        </div>
+      </section>
+
+      <!-- Fare Calculator -->
+      <section class="fare-card animate-in d4" id="fare-card">
+        <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
+        <div class="fare-body">
+          <div class="fare-route">
+            <div class="fare-station fare-from">
+              <span class="fare-station-label">From</span>
+              <span class="fare-station-name" id="fare-from-name">Union Station</span>
+            </div>
+            <div class="fare-arrow"><i class="ri-arrow-right-box-fill" aria-hidden="true"></i></div>
+            <div class="fare-station fare-to">
+              <span class="fare-station-label">To</span>
+              <select id="fare-destination" class="fare-select" aria-label="Select destination station">
+                <option value="">Select destination...</option>
+              </select>
+            </div>
+          </div>
+          <div class="fare-results" id="fare-results" style="display:none;">
+            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Station FAQ -->
+      <section class="station-faq animate-in d5">
+        <h2 class="station-faq-title">Frequently Asked Questions</h2>
+        <div class="station-faq-list">
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What Metro line serves Union Station?</summary>
+            <p class="station-faq-answer">Union Station is served by the Red Line, running between Shady Grove and Glenmont. It is located between Judiciary Square and NoMa-Gallaudet U stations.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">Can I connect to Amtrak, MARC, or VRE at Union Station?</summary>
+            <p class="station-faq-answer">Yes. Union Station is a major transportation hub with connections to Amtrak (nationwide rail), MARC commuter rail (Maryland), VRE commuter rail (Virginia), and the DC Streetcar (H Street line). The Metro station is located beneath the main Union Station building.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">Does Union Station Metro have parking?</summary>
+            <p class="station-faq-answer">The Metro station itself does not have a WMATA parking garage. However, Union Station has a large multi-level parking garage operated separately, accessible from H Street NE.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What is near Union Station Metro?</summary>
+            <p class="station-faq-answer">Union Station Metro is located beneath the historic Union Station building in the NoMa/Capitol Hill area. Nearby landmarks include the U.S. Capitol, Senate office buildings, the National Postal Museum, and Columbus Circle. The station is a short walk to the Capitol Hill neighborhood.</p>
+          </details>
+          <details class="station-faq-item">
+            <summary class="station-faq-question">What are the hours of operation for Union Station Metro?</summary>
+            <p class="station-faq-answer">Union Station Metro is open Monday through Thursday from 5:00 AM to midnight, Friday from 5:00 AM to 1:00 AM, Saturday from 7:00 AM to 1:00 AM, and Sunday from 7:00 AM to midnight. Note: the Union Station building itself may have different hours.</p>
+          </details>
+        </div>
+      </section>
+
+    </div>
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+
+      <!-- Adjacent Stations -->
+      <section class="adjacent-card animate-in d2">
+        <div class="adjacent-header">
+          <h2 class="adjacent-title">Adjacent Stations</h2>
+          <span class="adjacent-line-badge adjacent-line-badge--red">Red Line</span>
+        </div>
+        <div class="adjacent-body">
+          <a href="/station/judiciary-square/" class="adjacent-station adjacent-station--prev">
+            <span class="adjacent-direction"><i class="ri-arrow-left-s-line" aria-hidden="true"></i> Toward Shady Grove</span>
+            <span class="adjacent-name">Judiciary Square</span>
+          </a>
+          <div class="adjacent-divider"><span class="adjacent-current-dot"></span></div>
+          <a href="/station/noma/" class="adjacent-station adjacent-station--next">
+            <span class="adjacent-direction">Toward Glenmont <i class="ri-arrow-right-s-line" aria-hidden="true"></i></span>
+            <span class="adjacent-name">NoMa-Gallaudet U</span>
+          </a>
+        </div>
+      </section>
+
+      <!-- Station Facilities Card -->
+      <section class="facilities-card animate-in d3" id="facilities-card">
+        <div class="facilities-header"><h2 class="facilities-title">Station Facilities</h2></div>
+        <div class="facilities-body" id="facilities-body">
+          <div class="facilities-row">
+            <span class="facilities-icon"><i class="ri-arrow-up-down-line" aria-hidden="true"></i></span>
+            <span class="facilities-label">Elevators</span>
+            <span class="facilities-status facilities-status--ok" id="elevator-status">Operational</span>
+          </div>
+          <div class="facilities-row">
+            <span class="facilities-icon"><i class="ri-escalator-line" aria-hidden="true"></i></span>
+            <span class="facilities-label">Escalators</span>
+            <span class="facilities-status facilities-status--ok" id="escalator-status">Operational</span>
+          </div>
+        </div>
+        <div class="facilities-details" id="facilities-details" style="display:none;"></div>
+      </section>
+
+      <!-- System Status Card -->
+      <div class="system-status-card animate-in d2" id="system-status-card">
+        <div class="system-status-header">
+          <span>System Status</span>
+          <span class="system-status-time" id="system-status-time"></span>
+        </div>
+        <div class="system-status-rows" id="system-status-rows"></div>
+      </div>
+
+      <!-- Alert Card -->
+      <div class="alert-card animate-in d3" id="alert-card" style="display:none;">
+        <div class="alert-card-header">
+          <span class="alert-badge">Service Alert</span>
+          <span class="alert-timestamp" id="alert-timestamp"></span>
+        </div>
+        <div class="alert-card-body" id="alert-body"></div>
+      </div>
+
+    </aside>
+  </main>
+
+  <!-- NextMetro Site Footer -->
+  <footer class="nm-footer">
+    <div class="nm-footer__strip" aria-hidden="true">
+      <span></span><span></span><span></span><span></span><span></span><span></span>
+    </div>
+    <div class="nm-footer__body">
+      <div class="nm-footer__col">
+        <h2 class="nm-footer__heading">Navigate</h2>
+        <nav class="nm-footer__links" aria-label="Footer navigation">
+          <a href="/" class="nm-footer__link">Home</a>
+          <a href="https://wmata.com/schedules/maps/upload/system-map-rail.pdf" class="nm-footer__link" target="_blank" rel="noopener noreferrer" title="System Map (PDF, opens in new tab)" aria-label="System Map (PDF, opens in new tab)">System Map</a>
+          <a href="/alerts" class="nm-footer__link">Alerts</a>
+          <a href="/elevators" class="nm-footer__link">Elevator Status</a>
+          <a href="/fares" class="nm-footer__link">Fares</a>
+          <a href="/hours" class="nm-footer__link">Hours</a>
+        </nav>
+      </div>
+      <div class="nm-footer__col">
+        <h2 class="nm-footer__heading">Lines</h2>
+        <nav class="nm-footer__links" aria-label="Metro lines">
+          <a href="/lines/red" class="nm-footer__link nm-footer__link--line"><span class="nm-footer__dot nm-footer__dot--red"></span>Red Line</a>
+          <a href="/lines/orange" class="nm-footer__link nm-footer__link--line"><span class="nm-footer__dot nm-footer__dot--orange"></span>Orange Line</a>
+          <a href="/lines/silver" class="nm-footer__link nm-footer__link--line"><span class="nm-footer__dot nm-footer__dot--silver"></span>Silver Line</a>
+          <a href="/lines/blue" class="nm-footer__link nm-footer__link--line"><span class="nm-footer__dot nm-footer__dot--blue"></span>Blue Line</a>
+          <a href="/lines/yellow" class="nm-footer__link nm-footer__link--line"><span class="nm-footer__dot nm-footer__dot--yellow"></span>Yellow Line</a>
+          <a href="/lines/green" class="nm-footer__link nm-footer__link--line"><span class="nm-footer__dot nm-footer__dot--green"></span>Green Line</a>
+        </nav>
+      </div>
+      <div class="nm-footer__col">
+        <h2 class="nm-footer__heading">About</h2>
+        <nav class="nm-footer__links" aria-label="About">
+          <a href="/about" class="nm-footer__link">About NextMetro</a>
+          <a href="/privacy" class="nm-footer__link">Privacy Policy</a>
+          <a href="/terms" class="nm-footer__link">Terms of Service</a>
+          <a href="/crisis" class="nm-footer__link">Crisis Resources</a>
+          <a href="https://nickpoole.dev" class="nm-footer__link" target="_blank" rel="noopener noreferrer">Webmaster</a>
+        </nav>
+        <div class="nm-footer__data-block">
+          <h2 class="nm-footer__heading">Data</h2>
+          <p class="nm-footer__body-text">Real-time data via WMATA API.<br>Not affiliated with WMATA.</p>
+        </div>
+      </div>
+      <div class="nm-footer__col nm-footer__col--logo">
+        <div class="nm-footer__logo" role="img" aria-label="NextMetro">
+          <div class="nm-footer__logo-mark"><b>NM</b></div>
+          <div class="nm-footer__logo-strip" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span><span></span></div>
+          <div class="nm-footer__logo-text">
+            <span class="nm-footer__logo-next">NEXT</span>
+            <span class="nm-footer__logo-metro">METRO</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="nm-footer__bottom">
+      <span class="nm-footer__copy">&copy; 2026 NextMetro &middot; nextmetro.live</span>
+    </div>
+  </footer>
+  <script src="/js/nav.js"></script>
+  <script>
+  const STATION_CODE = 'B03';
+  </script>
+  <script src="/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds dedicated station pages for two major WMATA Metro stations: Metro Center (a 4-line transfer hub) and Potomac Yard (the newest station opened in 2023). It also introduces support for transfer stations with dual PIDS boards and updates the app architecture to support station-specific configurations.

## Key Changes

- **New Station Pages**
  - Metro Center (`public/station/metro-center/index.html`): Transfer station serving Red, Orange, Blue, and Silver Lines with dual platform PIDS displays
  - Potomac Yard (`public/station/potomac-yard/index.html`): Newest WMATA station serving Blue and Yellow Lines with hero image

- **Transfer Station Support**
  - Added `renderPlatformSkeletons()` and `renderPlatformPids()` functions to render separate PIDS boards for each platform
  - Implemented `fetchTransferTrains()` to fetch predictions independently for each platform without merging data
  - Added `TRANSFER_PLATFORMS` configuration support for stations with multiple platforms
  - Added `IS_TRANSFER_STATION` flag to control polling behavior

- **App Architecture Updates**
  - Modified `app.js` to support station-specific `STATION_CODE` override via global variable
  - Updated `fetchTrains()` to safely handle cases where `pidsContent` element doesn't exist
  - Added conditional polling logic to use `fetchTransferTrains()` for transfer stations

- **Styling Enhancements**
  - Added `.pids-grid` for side-by-side platform display (responsive to single column on mobile)
  - Added `.station-faq` styles for FAQ sections with expandable details
  - Added `.hero-transfer-badge` for visual transfer station indicator
  - Added `.line-strip-group` for displaying multiple line indicators in platform headers

- **SEO & Metadata**
  - Comprehensive Open Graph and Twitter Card metadata for both stations
  - Structured data (JSON-LD) including BreadcrumbList, TrainStation schema, and FAQPage
  - Station-specific FAQs addressing common questions about transfers, hours, and amenities

- **Station Information**
  - Metro Center: Address, station type, entrances, hours, neighborhood, bus connections
  - Potomac Yard: Address, opening date, station type, hours, bus connections
  - Fare calculators for both stations
  - Adjacent station navigation for each line served

## Implementation Details

- Transfer stations use separate API calls per platform to maintain independent train data
- Metro Center displays Platform A (Red Line) and Platform B (Orange/Blue/Silver) side-by-side
- Potomac Yard includes a hero image and highlights its status as WMATA's newest station
- Both pages include comprehensive station information, FAQ sections, and fare calculators
- Station pages can override the default station code by setting `STATION_CODE` before loading `app.js`

https://claude.ai/code/session_01TvBWML75sy38Sv3Xbg6PBr