### PR TITLE
Add Transfer Stations page and unified breadcrumb navigation

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -82,11 +82,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar" role="marquee" aria-label="Metro line status">
-    <div class="ticker-track"></div>
-  </div>
-
   <!-- Error Content -->
   <main id="main-content">
   <div class="error-page">

--- a/public/404.html
+++ b/public/404.html
@@ -120,6 +120,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/500.html
+++ b/public/500.html
@@ -82,11 +82,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar" role="marquee" aria-label="Metro line status">
-    <div class="ticker-track"></div>
-  </div>
-
   <!-- Error Content -->
   <main id="main-content">
   <div class="error-page">

--- a/public/500.html
+++ b/public/500.html
@@ -120,6 +120,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -104,6 +104,13 @@
   </div>
 
   <!-- About Content -->
+  <section class="about-hero">
+    <div class="about-hero-inner">
+      <span class="about-label">About</span>
+      <h1 class="about-title">NextMetro</h1>
+    </div>
+  </section>
+
   <main id="main-content">
 
   <nav class="nm-breadcrumb" aria-label="Breadcrumb">
@@ -113,13 +120,6 @@
       <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">About</li>
     </ol>
   </nav>
-
-  <section class="about-hero">
-    <div class="about-hero-inner">
-      <span class="about-label">About</span>
-      <h1 class="about-title">NextMetro</h1>
-    </div>
-  </section>
 
   <div class="about-page">
     <div class="about-section">

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -114,10 +114,14 @@
     </ol>
   </nav>
 
-  <div class="about-page">
-    <span class="about-label">About</span>
-    <h1 class="about-title">NextMetro</h1>
+  <section class="about-hero">
+    <div class="about-hero-inner">
+      <span class="about-label">About</span>
+      <h1 class="about-title">NextMetro</h1>
+    </div>
+  </section>
 
+  <div class="about-page">
     <div class="about-section">
       <p class="about-text">
         NextMetro is a real-time tracker for the Washington D.C. Metrorail system. It pulls live data from the
@@ -180,6 +184,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -105,6 +105,15 @@
 
   <!-- About Content -->
   <main id="main-content">
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">About</li>
+    </ol>
+  </nav>
+
   <div class="about-page">
     <span class="about-label">About</span>
     <h1 class="about-title">NextMetro</h1>

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -98,11 +98,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar" role="marquee" aria-label="Metro line status">
-    <div class="ticker-track"></div>
-  </div>
-
   <!-- About Content -->
   <section class="about-hero">
     <div class="about-hero-inner">

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -98,6 +98,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- About Content -->
   <section class="about-hero">
     <div class="about-hero-inner">
@@ -239,5 +253,6 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
 </body>
 </html>

--- a/public/alerts/index.html
+++ b/public/alerts/index.html
@@ -8,6 +8,7 @@
   <link rel="canonical" href="https://nextmetro.live/alerts/" />
   <link rel="stylesheet" href="/css/styles.css" />
   <link rel="stylesheet" href="/css/alerts-page.css" />
+  <link rel="stylesheet" href="/css/line.css" />
   <link rel="stylesheet" href="/css/nav.css" />
   <link rel="stylesheet" href="/css/footer.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -186,8 +187,19 @@
   <!-- Main Content -->
   <main id="main-content" class="alerts-page">
 
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Alerts</li>
+    </ol>
+  </nav>
+
   <!-- Page Hero -->
-  <section class="hero">
+  <section class="hero hero--has-image">
+    <div class="hero__image">
+      <img src="/images/eleven-photographs.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
+    </div>
     <div class="hero-inner">
       <span class="hero-label">Live Status</span>
       <h1 class="hero-station-name">DC Metro Alerts &amp; Outages</h1>
@@ -198,6 +210,37 @@
 
       <!-- Controls Bar -->
       <div class="alerts-controls animate-in d1">
+        <div class="alerts-controls-left">
+          <div class="alerts-filters" id="alerts-filters">
+            <button class="alerts-filter-chip alerts-filter-chip--active" data-line="all" aria-pressed="true">
+              <span class="alerts-filter-label">All</span>
+            </button>
+            <button class="alerts-filter-chip" data-line="RD" aria-pressed="false">
+              <span class="alerts-filter-dot" style="background-color:#D41140"></span>
+              <span class="alerts-filter-label">Red</span>
+            </button>
+            <button class="alerts-filter-chip" data-line="OR" aria-pressed="false">
+              <span class="alerts-filter-dot" style="background-color:#F09500"></span>
+              <span class="alerts-filter-label">Orange</span>
+            </button>
+            <button class="alerts-filter-chip" data-line="BL" aria-pressed="false">
+              <span class="alerts-filter-dot" style="background-color:#00A8E8"></span>
+              <span class="alerts-filter-label">Blue</span>
+            </button>
+            <button class="alerts-filter-chip" data-line="GR" aria-pressed="false">
+              <span class="alerts-filter-dot" style="background-color:#00BD45"></span>
+              <span class="alerts-filter-label">Green</span>
+            </button>
+            <button class="alerts-filter-chip" data-line="YL" aria-pressed="false">
+              <span class="alerts-filter-dot" style="background-color:#FFD400"></span>
+              <span class="alerts-filter-label">Yellow</span>
+            </button>
+            <button class="alerts-filter-chip" data-line="SV" aria-pressed="false">
+              <span class="alerts-filter-dot" style="background-color:#9BA5A5"></span>
+              <span class="alerts-filter-label">Silver</span>
+            </button>
+          </div>
+        </div>
         <div class="alerts-controls-right">
           <span class="alerts-updated" id="alerts-updated"></span>
           <button class="refresh-btn" id="alerts-refresh" aria-label="Refresh alerts">

--- a/public/alerts/index.html
+++ b/public/alerts/index.html
@@ -179,17 +179,17 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
-  <!-- System Ticker -->
-  <div class="ticker-bar" id="ticker-bar" role="marquee" aria-label="Metro line status">
-    <div class="ticker-track" id="ticker-track"></div>
-  </div>
-
   <!-- Hero -->
   <section class="alerts-hero">
     <div class="alerts-hero-inner">
       <span class="alerts-hero-label">Live Status</span>
       <h1 class="alerts-hero-title">DC Metro Alerts &amp; Outages</h1>
       <p class="alerts-hero-subtitle" id="alerts-subtitle">Train delays, station closures, single tracking, and elevator &amp; escalator outages — updated every 30 seconds.</p>
+
+      <!-- System Status Summary -->
+      <div class="alerts-status-bar animate-in d2" id="alerts-status-bar">
+        <!-- Rendered by JS -->
+      </div>
     </div>
   </section>
 
@@ -246,11 +246,6 @@
             <i class="ri-refresh-line" aria-hidden="true"></i>
           </button>
         </div>
-      </div>
-
-      <!-- System Status Summary -->
-      <div class="alerts-status-bar animate-in d2" id="alerts-status-bar">
-        <!-- Rendered by JS -->
       </div>
 
       <!-- Alerts List -->

--- a/public/alerts/index.html
+++ b/public/alerts/index.html
@@ -387,6 +387,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/alerts/index.html
+++ b/public/alerts/index.html
@@ -184,8 +184,17 @@
     <div class="ticker-track" id="ticker-track"></div>
   </div>
 
+  <!-- Hero -->
+  <section class="alerts-hero">
+    <div class="alerts-hero-inner">
+      <span class="alerts-hero-label">Live Status</span>
+      <h1 class="alerts-hero-title">DC Metro Alerts &amp; Outages</h1>
+      <p class="alerts-hero-subtitle" id="alerts-subtitle">Train delays, station closures, single tracking, and elevator &amp; escalator outages — updated every 30 seconds.</p>
+    </div>
+  </section>
+
   <!-- Main Content -->
-  <main id="main-content" class="alerts-page">
+  <main id="main-content">
 
   <nav class="nm-breadcrumb" aria-label="Breadcrumb">
     <ol class="nm-breadcrumb-list">
@@ -195,17 +204,7 @@
     </ol>
   </nav>
 
-  <!-- Page Hero -->
-  <section class="hero hero--has-image">
-    <div class="hero__image">
-      <img src="/images/eleven-photographs.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
-    </div>
-    <div class="hero-inner">
-      <span class="hero-label">Live Status</span>
-      <h1 class="hero-station-name">DC Metro Alerts &amp; Outages</h1>
-      <p class="hero-station-address" id="alerts-subtitle">Train delays, station closures, single tracking, and elevator &amp; escalator outages — updated every 30 seconds.</p>
-    </div>
-  </section>
+    <div class="alerts-page">
     <div class="alerts-page-inner">
 
       <!-- Controls Bar -->
@@ -365,6 +364,7 @@
     </div>
   </section>
 
+    </div>
   </main>
 
   <!-- NextMetro Site Footer -->

--- a/public/alerts/index.html
+++ b/public/alerts/index.html
@@ -179,6 +179,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Hero -->
   <section class="alerts-hero">
     <div class="alerts-hero-inner">
@@ -442,6 +456,7 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
   <script src="/js/shared.js"></script>
   <script src="/js/alerts.js"></script>
 </body>

--- a/public/crisis/index.html
+++ b/public/crisis/index.html
@@ -98,11 +98,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar" role="marquee" aria-label="Metro line status">
-    <div class="ticker-track"></div>
-  </div>
-
   <!-- Crisis Content -->
   <section class="crisis-hero">
     <div class="crisis-hero-inner">

--- a/public/crisis/index.html
+++ b/public/crisis/index.html
@@ -105,6 +105,15 @@
 
   <!-- Crisis Content -->
   <main id="main-content">
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Crisis Resources</li>
+    </ol>
+  </nav>
+
   <div class="crisis-page">
     <span class="crisis-label">Support</span>
     <h1 class="crisis-title">Crisis Resources</h1>

--- a/public/crisis/index.html
+++ b/public/crisis/index.html
@@ -98,6 +98,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Crisis Content -->
   <section class="crisis-hero">
     <div class="crisis-hero-inner">
@@ -242,5 +256,6 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
 </body>
 </html>

--- a/public/crisis/index.html
+++ b/public/crisis/index.html
@@ -104,6 +104,13 @@
   </div>
 
   <!-- Crisis Content -->
+  <section class="crisis-hero">
+    <div class="crisis-hero-inner">
+      <span class="crisis-label">Support</span>
+      <h1 class="crisis-title">Crisis Resources</h1>
+    </div>
+  </section>
+
   <main id="main-content">
 
   <nav class="nm-breadcrumb" aria-label="Breadcrumb">
@@ -113,13 +120,6 @@
       <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Crisis Resources</li>
     </ol>
   </nav>
-
-  <section class="crisis-hero">
-    <div class="crisis-hero-inner">
-      <span class="crisis-label">Support</span>
-      <h1 class="crisis-title">Crisis Resources</h1>
-    </div>
-  </section>
 
   <div class="crisis-page">
     <div class="crisis-banner">

--- a/public/crisis/index.html
+++ b/public/crisis/index.html
@@ -114,10 +114,14 @@
     </ol>
   </nav>
 
-  <div class="crisis-page">
-    <span class="crisis-label">Support</span>
-    <h1 class="crisis-title">Crisis Resources</h1>
+  <section class="crisis-hero">
+    <div class="crisis-hero-inner">
+      <span class="crisis-label">Support</span>
+      <h1 class="crisis-title">Crisis Resources</h1>
+    </div>
+  </section>
 
+  <div class="crisis-page">
     <div class="crisis-banner">
       <span class="crisis-banner-number">988</span>
       <div class="crisis-banner-text">
@@ -183,6 +187,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/css/about.css
+++ b/public/css/about.css
@@ -2,8 +2,8 @@
    NextMetro — About Page Styles
    ============================== */
 .about-hero {
-  background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.7)),
-    url('/images/matthew-bornhorst.jpg') center / cover no-repeat;
+  background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.65)),
+    url('/images/about-hero.webp') center / cover no-repeat;
   background-color: var(--nm-surface);
   padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
   border-bottom: 1px solid var(--nm-border-subtle);

--- a/public/css/about.css
+++ b/public/css/about.css
@@ -1,10 +1,23 @@
 /* ==============================
    NextMetro — About Page Styles
    ============================== */
+.about-hero {
+  background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.7)),
+    url('/images/matthew-bornhorst.jpg') center / cover no-repeat;
+  background-color: var(--nm-surface);
+  padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
+  border-bottom: 1px solid var(--nm-border-subtle);
+}
+
+.about-hero-inner {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
 .about-page {
   max-width: 720px;
   margin: 0 auto;
-  padding: 3rem 1.5rem 4rem;
+  padding: 2rem 1.5rem 4rem;
 }
 
 .about-label {

--- a/public/css/alerts-page.css
+++ b/public/css/alerts-page.css
@@ -39,6 +39,10 @@
   margin-bottom: var(--nm-space-sm);
 }
 
+.alerts-hero .alerts-status-bar {
+  margin-top: var(--nm-space-lg);
+}
+
 .alerts-hero-subtitle {
   font-family: var(--nm-font);
   font-weight: 400;

--- a/public/css/alerts-page.css
+++ b/public/css/alerts-page.css
@@ -2,6 +2,52 @@
 /* ==============================
    Alerts Page
    ============================== */
+
+/* ---- Alerts Hero ---- */
+.alerts-hero {
+  padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
+  border-bottom: 1px solid var(--nm-border-subtle);
+  background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.65)),
+    url('/images/alerts-hero.webp') center / cover no-repeat;
+  background-color: var(--nm-surface);
+}
+
+.alerts-hero-inner {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.alerts-hero-label {
+  display: block;
+  font-family: var(--nm-font);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: var(--nm-amber-dim);
+  letter-spacing: 0.12em;
+  margin-bottom: var(--nm-space-xs);
+}
+
+.alerts-hero-title {
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 2.5rem);
+  color: var(--nm-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1.1;
+  margin-bottom: var(--nm-space-sm);
+}
+
+.alerts-hero-subtitle {
+  font-family: var(--nm-font);
+  font-weight: 400;
+  font-size: 1rem;
+  color: var(--nm-text-primary);
+  line-height: 1.6;
+  max-width: 600px;
+}
+
 .alerts-page {
   max-width: 900px;
   margin: 0 auto;

--- a/public/css/crisis.css
+++ b/public/css/crisis.css
@@ -2,8 +2,8 @@
    NextMetro — Crisis Page Styles
    ============================== */
 .crisis-hero {
-  background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.7)),
-    url('/images/sara-cottle.jpg') center / cover no-repeat;
+  background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.65)),
+    url('/images/crisis-hero.webp') center / cover no-repeat;
   background-color: var(--nm-surface);
   padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
   border-bottom: 1px solid var(--nm-border-subtle);

--- a/public/css/crisis.css
+++ b/public/css/crisis.css
@@ -1,10 +1,23 @@
 /* ==============================
    NextMetro — Crisis Page Styles
    ============================== */
+.crisis-hero {
+  background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.7)),
+    url('/images/sara-cottle.jpg') center / cover no-repeat;
+  background-color: var(--nm-surface);
+  padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
+  border-bottom: 1px solid var(--nm-border-subtle);
+}
+
+.crisis-hero-inner {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
 .crisis-page {
   max-width: 720px;
   margin: 0 auto;
-  padding: 3rem 1.5rem 4rem;
+  padding: 2rem 1.5rem 4rem;
 }
 
 .crisis-label {

--- a/public/css/elevators-page.css
+++ b/public/css/elevators-page.css
@@ -2,6 +2,52 @@
 /* ==============================
    Elevator & Escalator Status Page
    ============================== */
+
+/* ---- Elevators Hero ---- */
+.elevators-hero {
+  padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
+  border-bottom: 1px solid var(--nm-border-subtle);
+  background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.65)),
+    url('/images/elevators-hero.webp') center / cover no-repeat;
+  background-color: var(--nm-surface);
+}
+
+.elevators-hero-inner {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.elevators-hero-label {
+  display: block;
+  font-family: var(--nm-font);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: var(--nm-amber-dim);
+  letter-spacing: 0.12em;
+  margin-bottom: var(--nm-space-xs);
+}
+
+.elevators-hero-title {
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 2.5rem);
+  color: var(--nm-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1.1;
+  margin-bottom: var(--nm-space-sm);
+}
+
+.elevators-hero-subtitle {
+  font-family: var(--nm-font);
+  font-weight: 400;
+  font-size: 1rem;
+  color: var(--nm-text-primary);
+  line-height: 1.6;
+  max-width: 600px;
+}
+
 .elev-page {
   max-width: 900px;
   margin: 0 auto;

--- a/public/css/fares.css
+++ b/public/css/fares.css
@@ -9,8 +9,8 @@
 }
 
 .fares-hero {
-  background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.7)),
-    url('/images/sam-jotham-sutharson.jpg') center / cover no-repeat;
+  background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.65)),
+    url('/images/fares-hero.webp') center / cover no-repeat;
   background-color: var(--nm-surface);
   padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
   border-bottom: 1px solid var(--nm-border-subtle);

--- a/public/css/fares.css
+++ b/public/css/fares.css
@@ -9,6 +9,8 @@
 }
 
 .fares-hero {
+  background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.7)),
+    url('/images/sam-jotham-sutharson.jpg') center / cover no-repeat;
   background-color: var(--nm-surface);
   padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
   border-bottom: 1px solid var(--nm-border-subtle);

--- a/public/css/footer.css
+++ b/public/css/footer.css
@@ -77,7 +77,7 @@
 .nm-footer__links {
   display: flex;
   flex-direction: column;
-  gap: 9px;
+  gap: 0;
 }
 
 .nm-footer__link {
@@ -88,6 +88,10 @@
   color: var(--nm-gray);
   text-decoration: none;
   transition: color 0.12s ease;
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 4px 0;
 }
 .nm-footer__link:hover {
   color: var(--nm-white);
@@ -102,6 +106,8 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  min-height: 24px;
+  padding: 4px 0;
 }
 .nm-footer__dot {
   width: 8px;
@@ -224,6 +230,10 @@
   text-decoration: none;
   transition: color 0.12s ease;
   font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 4px 0;
 }
 .nm-footer__legal a:hover {
   color: var(--nm-white);

--- a/public/css/line.css
+++ b/public/css/line.css
@@ -13,11 +13,43 @@ main[data-line] {
   background-color: var(--line-surface, var(--nm-surface));
   padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
   border-bottom: 1px solid var(--nm-border-subtle);
+  position: relative;
+  overflow: hidden;
 }
 
 .line-hero-inner {
   max-width: 900px;
   margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.line-hero__image {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.line-hero__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+  opacity: 0.08;
+  mix-blend-mode: luminosity;
+}
+
+.line-hero__image img[data-error] {
+  opacity: 0;
+}
+
+.line-hero__image::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-color: var(--line-surface, var(--nm-surface));
+  opacity: 0.7;
 }
 
 .line-hero-label {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -431,3 +431,65 @@ a:hover {
   white-space: nowrap;
   border: 0;
 }
+
+/* ==============================
+   Unified Breadcrumb
+   Positioned as first element inside #main, above hero.
+   Large tap targets, underlined links, visible on all backgrounds.
+   ============================== */
+.nm-breadcrumb {
+  background-color: var(--nm-bg);
+  padding: var(--nm-space-sm) var(--nm-space-lg);
+  border-bottom: 1px solid var(--nm-border-subtle);
+}
+
+.nm-breadcrumb-list {
+  display: flex;
+  align-items: center;
+  gap: var(--nm-space-xs);
+  list-style: none;
+  max-width: 1200px;
+  margin: 0 auto;
+  font-family: var(--nm-font);
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.nm-breadcrumb-item a {
+  color: var(--nm-text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: var(--nm-border-strong);
+  transition: color var(--nm-transition-normal), text-decoration-color var(--nm-transition-normal);
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 4px;
+}
+
+.nm-breadcrumb-item a:hover {
+  color: var(--nm-amber);
+  text-decoration-color: var(--nm-amber);
+}
+
+.nm-breadcrumb-sep {
+  color: var(--nm-text-disabled);
+  font-size: 0.75rem;
+  user-select: none;
+}
+
+.nm-breadcrumb-current {
+  color: var(--nm-text-muted);
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 4px;
+}
+
+@media (max-width: 768px) {
+  .nm-breadcrumb {
+    padding: var(--nm-space-sm) var(--nm-space-md);
+  }
+}

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -448,7 +448,7 @@ a:hover {
   align-items: center;
   gap: var(--nm-space-xs);
   list-style: none;
-  max-width: 1200px;
+  max-width: 900px;
   margin: 0 auto;
   font-family: var(--nm-font);
   font-size: 0.9rem;

--- a/public/css/transfers.css
+++ b/public/css/transfers.css
@@ -1,4 +1,50 @@
 /* Transfer Stations Page Styles */
+
+/* ---- Transfers Hero ---- */
+.transfers-hero {
+  padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
+  border-bottom: 1px solid var(--nm-border-subtle);
+  background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.65)),
+    url('/images/transfers-hero.webp') center / cover no-repeat;
+  background-color: var(--nm-surface);
+}
+
+.transfers-hero-inner {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.transfers-hero-label {
+  display: block;
+  font-family: var(--nm-font);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: var(--nm-amber-dim);
+  letter-spacing: 0.12em;
+  margin-bottom: var(--nm-space-xs);
+}
+
+.transfers-hero-title {
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 2.5rem);
+  color: var(--nm-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1.1;
+  margin-bottom: var(--nm-space-sm);
+}
+
+.transfers-hero-subtitle {
+  font-family: var(--nm-font);
+  font-weight: 400;
+  font-size: 1rem;
+  color: var(--nm-text-primary);
+  line-height: 1.6;
+  max-width: 600px;
+}
+
 .transfers-page {
   max-width: 900px;
   margin: 0 auto;

--- a/public/css/transfers.css
+++ b/public/css/transfers.css
@@ -1,0 +1,206 @@
+/* Transfer Stations Page Styles */
+.transfers-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: var(--nm-space-xl) var(--nm-space-lg) var(--nm-space-3xl);
+}
+
+.transfers-section {
+  margin-top: var(--nm-space-2xl);
+}
+
+.transfers-section-heading {
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: var(--nm-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  margin-bottom: var(--nm-space-sm);
+  padding-bottom: 0.35rem;
+  border-bottom: 2px solid var(--nm-amber-dim);
+  display: inline-block;
+}
+
+.transfers-section-desc {
+  font-family: var(--nm-font);
+  font-weight: 400;
+  font-size: 1rem;
+  color: var(--nm-text-secondary);
+  line-height: 1.6;
+  margin-bottom: var(--nm-space-lg);
+}
+
+.transfer-station-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--nm-space-md);
+}
+
+.transfer-station-card {
+  display: flex;
+  align-items: center;
+  gap: var(--nm-space-lg);
+  padding: var(--nm-space-lg) 1.25rem;
+  background-color: var(--nm-surface);
+  border: 1px solid var(--nm-border);
+  text-decoration: none;
+  transition: background-color var(--nm-transition-fast), border-color var(--nm-transition-fast);
+  min-height: 80px;
+}
+
+.transfer-station-card:hover {
+  background-color: var(--nm-surface-elevated);
+  border-color: var(--nm-border-strong);
+}
+
+.transfer-station-card:hover .transfer-station-name {
+  color: var(--nm-amber);
+}
+
+.transfer-station-card:hover .transfer-station-arrow {
+  color: var(--nm-amber);
+}
+
+.transfer-station-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.transfer-station-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50% !important;
+  display: block;
+}
+
+.transfer-station-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.transfer-station-name {
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: var(--nm-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  margin: 0 0 4px;
+  transition: color var(--nm-transition-normal);
+}
+
+.transfer-station-desc {
+  font-family: var(--nm-font);
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--nm-text-secondary);
+  margin: 0 0 2px;
+}
+
+.transfer-station-detail {
+  font-family: var(--nm-font);
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: var(--nm-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.transfer-station-arrow {
+  color: var(--nm-text-muted);
+  flex-shrink: 0;
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  transition: color var(--nm-transition-normal);
+}
+
+/* Walking Transfer Card */
+.transfer-walking-card {
+  display: flex;
+  align-items: center;
+  gap: var(--nm-space-lg);
+  padding: var(--nm-space-lg) 1.25rem;
+  background-color: var(--nm-surface);
+  border: 1px solid var(--nm-border);
+  border-left: 4px solid var(--nm-amber-dim);
+}
+
+.transfer-walking-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  color: var(--nm-amber-dim);
+  font-size: 1.5rem;
+  flex-shrink: 0;
+}
+
+.transfer-walking-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.transfer-walking-name {
+  font-family: var(--nm-font);
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--nm-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  margin: 0 0 4px;
+}
+
+.transfer-walking-desc {
+  font-family: var(--nm-font);
+  font-weight: 400;
+  font-size: 0.95rem;
+  color: var(--nm-text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Transfers Disclaimer */
+.transfers-disclaimer {
+  background-color: var(--nm-surface-elevated);
+  border: 1px solid var(--nm-border);
+  padding: 1rem 1.25rem;
+  margin-top: var(--nm-space-2xl);
+}
+
+.transfers-disclaimer p {
+  font-family: var(--nm-font);
+  font-size: 1rem;
+  color: var(--nm-text-secondary);
+  line-height: 1.7;
+}
+
+.transfers-disclaimer a {
+  color: var(--nm-amber);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .transfers-page {
+    padding: var(--nm-space-lg) var(--nm-space-md) var(--nm-space-2xl);
+  }
+
+  .transfer-station-card {
+    padding: var(--nm-space-md) var(--nm-space-md);
+    gap: var(--nm-space-md);
+  }
+
+  .transfer-station-name {
+    font-size: 1.1rem;
+  }
+
+  .transfer-walking-card {
+    padding: var(--nm-space-md) var(--nm-space-md);
+    gap: var(--nm-space-md);
+  }
+}

--- a/public/elevators/index.html
+++ b/public/elevators/index.html
@@ -366,6 +366,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/elevators/index.html
+++ b/public/elevators/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="/css/styles.css" />
   <link rel="stylesheet" href="/css/alerts-page.css" />
   <link rel="stylesheet" href="/css/elevators-page.css" />
+  <link rel="stylesheet" href="/css/line.css" />
   <link rel="stylesheet" href="/css/nav.css" />
   <link rel="stylesheet" href="/css/footer.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -170,8 +171,19 @@
   <!-- Main Content -->
   <main id="main-content" class="elev-page">
 
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Elevators</li>
+    </ol>
+  </nav>
+
   <!-- Page Hero -->
-  <section class="hero">
+  <section class="hero hero--has-image">
+    <div class="hero__image">
+      <img src="/images/escalator-hero.webp" alt="" loading="eager" onerror="this.dataset.error=true" />
+    </div>
     <div class="hero-inner">
       <span class="hero-label">Live Status</span>
       <h1 class="hero-station-name">Elevator &amp; Escalator Outages</h1>

--- a/public/elevators/index.html
+++ b/public/elevators/index.html
@@ -168,8 +168,17 @@
     <div class="ticker-track" id="ticker-track"></div>
   </div>
 
+  <!-- Hero -->
+  <section class="elevators-hero">
+    <div class="elevators-hero-inner">
+      <span class="elevators-hero-label">Live Status</span>
+      <h1 class="elevators-hero-title">Elevator &amp; Escalator Outages</h1>
+      <p class="elevators-hero-subtitle" id="elev-subtitle">Real-time elevator and escalator status for every DC Metro station — updated every 30 seconds.</p>
+    </div>
+  </section>
+
   <!-- Main Content -->
-  <main id="main-content" class="elev-page">
+  <main id="main-content">
 
   <nav class="nm-breadcrumb" aria-label="Breadcrumb">
     <ol class="nm-breadcrumb-list">
@@ -179,17 +188,7 @@
     </ol>
   </nav>
 
-  <!-- Page Hero -->
-  <section class="hero hero--has-image">
-    <div class="hero__image">
-      <img src="/images/escalator-hero.webp" alt="" loading="eager" onerror="this.dataset.error=true" />
-    </div>
-    <div class="hero-inner">
-      <span class="hero-label">Live Status</span>
-      <h1 class="hero-station-name">Elevator &amp; Escalator Outages</h1>
-      <p class="hero-station-address" id="elev-subtitle">Real-time elevator and escalator status for every DC Metro station — updated every 30 seconds.</p>
-    </div>
-  </section>
+    <div class="elev-page">
     <div class="elev-page-inner">
 
       <!-- Controls Bar -->
@@ -344,6 +343,7 @@
     </div>
   </section>
 
+    </div>
   </main>
 
   <!-- NextMetro Site Footer -->

--- a/public/elevators/index.html
+++ b/public/elevators/index.html
@@ -163,6 +163,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Hero -->
   <section class="elevators-hero">
     <div class="elevators-hero-inner">
@@ -421,6 +435,7 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
   <script src="/js/shared.js"></script>
   <script src="/js/elevators.js"></script>
 </body>

--- a/public/elevators/index.html
+++ b/public/elevators/index.html
@@ -163,11 +163,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
-  <!-- System Ticker -->
-  <div class="ticker-bar" id="ticker-bar" role="marquee" aria-label="Metro line status">
-    <div class="ticker-track" id="ticker-track"></div>
-  </div>
-
   <!-- Hero -->
   <section class="elevators-hero">
     <div class="elevators-hero-inner">

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -145,6 +145,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Hero -->
   <section class="fares-hero">
     <div class="fares-hero-inner">
@@ -460,6 +474,7 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
   <script src="/js/shared.js"></script>
   <script src="/js/fares.js"></script>
 </body>

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -405,6 +405,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -150,16 +150,6 @@
     <div class="ticker-track"></div>
   </div>
 
-  <main id="main-content">
-
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Fares</li>
-    </ol>
-  </nav>
-
   <!-- Hero -->
   <section class="fares-hero">
     <div class="fares-hero-inner">
@@ -175,6 +165,16 @@
       </div>
     </div>
   </section>
+
+  <main id="main-content">
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Fares</li>
+    </ol>
+  </nav>
 
   <!-- Main Content -->
   <div class="fares-page">

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -145,11 +145,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar" role="marquee" aria-label="Metro line status">
-    <div class="ticker-track"></div>
-  </div>
-
   <!-- Hero -->
   <section class="fares-hero">
     <div class="fares-hero-inner">

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -151,6 +151,15 @@
   </div>
 
   <main id="main-content">
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Fares</li>
+    </ol>
+  </nav>
+
   <!-- Hero -->
   <section class="fares-hero">
     <div class="fares-hero-inner">

--- a/public/hours/index.html
+++ b/public/hours/index.html
@@ -981,6 +981,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/hours/index.html
+++ b/public/hours/index.html
@@ -154,6 +154,20 @@
     <a href="/hours" class="mobile-menu-link mobile-menu-link--active" aria-current="page">Hours</a>
   </nav>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Hero -->
   <section class="hours-hero">
     <div class="hours-hero-inner">
@@ -1037,6 +1051,7 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
   <script src="/js/hours.js"></script>
 </body>
 </html>

--- a/public/hours/index.html
+++ b/public/hours/index.html
@@ -175,6 +175,15 @@
   </section>
 
   <main id="main-content">
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Hours</li>
+    </ol>
+  </nav>
+
   <div class="hours-page">
 
     <!-- Operating Hours -->

--- a/public/hours/index.html
+++ b/public/hours/index.html
@@ -8,6 +8,7 @@
   <link rel="canonical" href="https://nextmetro.live/hours/" />
   <link rel="stylesheet" href="/css/styles.css" />
   <link rel="stylesheet" href="/css/hours.css" />
+  <link rel="stylesheet" href="/css/line.css" />
   <link rel="stylesheet" href="/css/nav.css" />
   <link rel="stylesheet" href="/css/footer.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -152,11 +153,6 @@
     <a href="/fares" class="mobile-menu-link">Fares</a>
     <a href="/hours" class="mobile-menu-link mobile-menu-link--active" aria-current="page">Hours</a>
   </nav>
-
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar" role="marquee" aria-label="Metro line status">
-    <div class="ticker-track"></div>
-  </div>
 
   <!-- Hero -->
   <section class="hours-hero">

--- a/public/index.html
+++ b/public/index.html
@@ -327,6 +327,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/js/alerts.js
+++ b/public/js/alerts.js
@@ -107,6 +107,7 @@ function normalizeElevatorIncidents(elevatorIncidents) {
 // ---- State ----
 var currentAlerts = []; // unified list: rail incidents + elevator/escalator
 var currentRailIncidents = []; // rail-only for ticker + status bar
+var activeLineFilter = 'all'; // 'all' | line code
 var pollingInterval = null;
 
 // ---- DOM ----
@@ -118,6 +119,7 @@ var alertsStatusBar = document.getElementById('alerts-status-bar');
 var metaDescription = document.getElementById('meta-description');
 var schemaAlerts = document.getElementById('schema-alerts');
 var lastUpdatedTime = document.getElementById('alerts-last-updated-time');
+var alertsFilters = document.getElementById('alerts-filters');
 
 // renderTicker — from shared.js
 
@@ -163,6 +165,21 @@ function renderStatusBar(incidents) {
   });
 
   alertsStatusBar.innerHTML = html;
+}
+
+// ==============================
+// Apply Line Filter
+// ==============================
+function getFilteredAlerts() {
+  if (activeLineFilter === 'all') return currentAlerts;
+  return currentAlerts.filter(function (incident) {
+    // Rail incidents — check LinesAffected
+    var lines = parseAffectedLines(incident.LinesAffected);
+    if (lines.length > 0) return lines.indexOf(activeLineFilter) !== -1;
+    // Elevator/escalator — check station code prefix
+    if (incident._station) return true; // Show facility alerts for all line filters
+    return true;
+  });
 }
 
 // ==============================
@@ -242,20 +259,26 @@ function formatAlertTime(dateStr) {
 // Render Alert Cards
 // ==============================
 function renderAlerts() {
-  if (currentAlerts.length === 0) {
+  var filteredAlerts = getFilteredAlerts();
+  if (filteredAlerts.length === 0) {
     alertsList.innerHTML = '';
     alertsEmpty.style.display = '';
     var emptyTitle = alertsEmpty.querySelector('.alerts-empty-title');
     var emptyText = alertsEmpty.querySelector('.alerts-empty-text');
-    emptyTitle.textContent = 'All Clear';
-    emptyText.textContent = 'No active service alerts. All lines and stations operating normally.';
+    if (activeLineFilter !== 'all') {
+      emptyTitle.textContent = 'No Matching Alerts';
+      emptyText.textContent = 'No active alerts for this line. Try selecting a different line or viewing all alerts.';
+    } else {
+      emptyTitle.textContent = 'All Clear';
+      emptyText.textContent = 'No active service alerts. All lines and stations operating normally.';
+    }
     return;
   }
 
   alertsEmpty.style.display = 'none';
 
   // Sort by severity (worst first), then by date (newest first)
-  var sorted = currentAlerts.slice().sort(function (a, b) {
+  var sorted = filteredAlerts.slice().sort(function (a, b) {
     var sevA = getSeverity(a.IncidentType);
     var sevB = getSeverity(b.IncidentType);
     if (sevA !== sevB) return sevA - sevB;
@@ -462,6 +485,24 @@ document.addEventListener('DOMContentLoaded', async function () {
 
   await fetchAllAlerts();
   startPolling();
+});
+
+alertsFilters.addEventListener('click', function (e) {
+  var chip = e.target.closest('.alerts-filter-chip');
+  if (!chip) return;
+  var line = chip.dataset.line;
+  if (!line) return;
+
+  activeLineFilter = line;
+
+  var chips = alertsFilters.querySelectorAll('.alerts-filter-chip');
+  chips.forEach(function (c) {
+    var isActive = c.dataset.line === line;
+    c.classList.toggle('alerts-filter-chip--active', isActive);
+    c.setAttribute('aria-pressed', String(isActive));
+  });
+
+  renderAlerts();
 });
 
 alertsRefresh.addEventListener('click', function () {

--- a/public/js/alerts.js
+++ b/public/js/alerts.js
@@ -121,8 +121,6 @@ var schemaAlerts = document.getElementById('schema-alerts');
 var lastUpdatedTime = document.getElementById('alerts-last-updated-time');
 var alertsFilters = document.getElementById('alerts-filters');
 
-// renderTicker — from shared.js
-
 // ==============================
 // Status Summary Bar (rail incidents only)
 // ==============================
@@ -456,7 +454,6 @@ async function fetchAllAlerts() {
   currentAlerts = railIncidents.concat(elevatorIncidents);
 
   renderAlerts();
-  renderTicker(currentRailIncidents);
   renderStatusBar(currentRailIncidents);
   updateTimestamp();
   updateSEO(currentAlerts);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -236,7 +236,7 @@ function updateHeroDisplay(stationCode) {
   fareFromName.textContent = name;
 }
 
-// renderTicker, parseAffectedLines, escapeHtml — from shared.js
+// parseAffectedLines, escapeHtml — from shared.js
 
 // ==============================
 // Incidents Fetching & Rendering
@@ -249,7 +249,6 @@ async function fetchIncidents() {
     currentIncidents = data.Incidents || [];
 
     renderSystemStatus(currentIncidents);
-    renderTicker(currentIncidents);
     renderAlerts(currentIncidents, selectedStation);
   } catch (err) {
     console.error('Failed to fetch incidents:', err.message);

--- a/public/js/elevators.js
+++ b/public/js/elevators.js
@@ -38,22 +38,6 @@ var lastUpdatedTime = document.getElementById('elev-last-updated-time');
 var seoStations = document.getElementById('elev-seo-stations');
 
 // ==============================
-// Ticker (fetch rail incidents for line status)
-// ==============================
-async function fetchAndRenderTicker() {
-  try {
-    var res = await fetchWithRetry(API_BASE_URL + '/api/incidents');
-    if (!res || !res.ok) return;
-    var data = await res.json();
-    renderTicker(data.Incidents || []);
-  } catch (e) {
-    // Ticker is supplementary — fail silently
-  }
-}
-
-// parseAffectedLines, renderTicker, escapeHtml — from shared.js
-
-// ==============================
 // Get lines for a station code
 // ==============================
 function getLinesForStation(stationCode) {
@@ -403,7 +387,6 @@ elevLineFilters.addEventListener('click', function (e) {
 
 elevRefresh.addEventListener('click', function () {
   fetchOutages();
-  fetchAndRenderTicker();
 });
 
 // ==============================
@@ -427,6 +410,6 @@ document.addEventListener('DOMContentLoaded', async function () {
     // Backend may be sleeping
   }
 
-  await Promise.all([fetchOutages(), fetchAndRenderTicker()]);
+  await fetchOutages();
   startPolling();
 });

--- a/public/js/line.js
+++ b/public/js/line.js
@@ -17,7 +17,7 @@ const lineAlertsBody = document.getElementById('line-alerts-body');
 // ---- State ----
 let incidentsInterval = null;
 
-// escapeHtml, parseAffectedLines, renderTicker — from shared.js
+// escapeHtml, parseAffectedLines — from shared.js
 
 // ==============================
 // Line Status Hero
@@ -100,12 +100,10 @@ async function fetchIncidents() {
     const data = await res.json();
     const incidents = data.Incidents || [];
 
-    renderTicker(incidents);
     renderLineStatus(incidents);
     renderAlerts(incidents);
   } catch (err) {
     console.error('Failed to fetch incidents:', err.message);
-    renderTicker([]);
     lineStatusDot.className = 'line-status-dot line-status-dot--ok';
     lineStatusText.textContent = LINE_NAME + ' Line is running normally';
   }
@@ -122,9 +120,6 @@ function startPolling() {
 // Init
 // ==============================
 document.addEventListener('DOMContentLoaded', async () => {
-  // Show ticker with all-normal state before API response
-  renderTicker([]);
-
   // Wake up backend
   try {
     await fetchWithRetry(API_BASE_URL + '/healthz', 3, 2000);

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -1,0 +1,208 @@
+// ==============================
+// NextMetro — Global Station Search
+// Standalone search bar for core & line pages.
+// Uses the same station data as home.js.
+// Always navigates to /station/{slug}/ on selection.
+// ==============================
+
+(function () {
+  var searchStations = [
+    { name: 'Metro Center', slug: 'metro-center', lines: ['red', 'orange', 'blue', 'silver'] },
+    { name: 'Farragut North', slug: 'farragut-north', lines: ['red'] },
+    { name: 'Dupont Circle', slug: 'dupont-circle', lines: ['red'] },
+    { name: 'Woodley Park-Zoo/Adams Morgan', slug: 'woodley-park', lines: ['red'] },
+    { name: 'Cleveland Park', slug: 'cleveland-park', lines: ['red'] },
+    { name: 'Van Ness-UDC', slug: 'van-ness-udc', lines: ['red'] },
+    { name: 'Tenleytown-AU', slug: 'tenleytown-au', lines: ['red'] },
+    { name: 'Friendship Heights', slug: 'friendship-heights', lines: ['red'] },
+    { name: 'Bethesda', slug: 'bethesda', lines: ['red'] },
+    { name: 'Medical Center', slug: 'medical-center', lines: ['red'] },
+    { name: 'Grosvenor-Strathmore', slug: 'grosvenor-strathmore', lines: ['red'] },
+    { name: 'North Bethesda-White Flint', slug: 'north-bethesda', lines: ['red'] },
+    { name: 'Twinbrook', slug: 'twinbrook', lines: ['red'] },
+    { name: 'Rockville', slug: 'rockville', lines: ['red'] },
+    { name: 'Shady Grove', slug: 'shady-grove', lines: ['red'] },
+    { name: 'Gallery Pl-Chinatown', slug: 'gallery-place', lines: ['red', 'yellow', 'green'] },
+    { name: 'Judiciary Square', slug: 'judiciary-square', lines: ['red'] },
+    { name: 'Union Station', slug: 'union-station', lines: ['red'] },
+    { name: 'Rhode Island Ave-Brentwood', slug: 'rhode-island-ave', lines: ['red'] },
+    { name: 'Brookland-CUA', slug: 'brookland-cua', lines: ['red'] },
+    { name: 'Fort Totten', slug: 'fort-totten', lines: ['red', 'yellow', 'green'] },
+    { name: 'Takoma', slug: 'takoma', lines: ['red'] },
+    { name: 'Silver Spring', slug: 'silver-spring', lines: ['red'] },
+    { name: 'Forest Glen', slug: 'forest-glen', lines: ['red'] },
+    { name: 'Wheaton', slug: 'wheaton', lines: ['red'] },
+    { name: 'Glenmont', slug: 'glenmont', lines: ['red'] },
+    { name: 'NoMa-Gallaudet U', slug: 'noma', lines: ['red'] },
+    { name: 'McPherson Square', slug: 'mcpherson-square', lines: ['orange', 'blue', 'silver'] },
+    { name: 'Farragut West', slug: 'farragut-west', lines: ['orange', 'blue', 'silver'] },
+    { name: 'Foggy Bottom-GWU', slug: 'foggy-bottom', lines: ['orange', 'blue', 'silver'] },
+    { name: 'Rosslyn', slug: 'rosslyn', lines: ['orange', 'blue', 'silver'] },
+    { name: 'Arlington Cemetery', slug: 'arlington-cemetery', lines: ['blue'] },
+    { name: 'Pentagon', slug: 'pentagon', lines: ['blue', 'yellow'] },
+    { name: 'Pentagon City', slug: 'pentagon-city', lines: ['blue', 'yellow'] },
+    { name: 'Crystal City', slug: 'crystal-city', lines: ['blue', 'yellow'] },
+    { name: 'Ronald Reagan Washington National Airport', slug: 'reagan-airport', lines: ['blue', 'yellow'] },
+    { name: 'Potomac Yard', slug: 'potomac-yard', lines: ['blue', 'yellow'] },
+    { name: 'Braddock Road', slug: 'braddock-road', lines: ['blue', 'yellow'] },
+    { name: 'King St-Old Town', slug: 'king-street', lines: ['blue', 'yellow'] },
+    { name: 'Eisenhower Avenue', slug: 'eisenhower-ave', lines: ['blue'] },
+    { name: 'Huntington', slug: 'huntington', lines: ['blue'] },
+    { name: 'Federal Triangle', slug: 'federal-triangle', lines: ['orange', 'blue', 'silver'] },
+    { name: 'Smithsonian', slug: 'smithsonian', lines: ['orange', 'blue', 'silver'] },
+    { name: "L'Enfant Plaza", slug: 'lenfant-plaza', lines: ['orange', 'blue', 'yellow', 'green', 'silver'] },
+    { name: 'Federal Center SW', slug: 'federal-center-sw', lines: ['orange', 'blue', 'silver'] },
+    { name: 'Capitol South', slug: 'capitol-south', lines: ['orange', 'blue', 'silver'] },
+    { name: 'Eastern Market', slug: 'eastern-market', lines: ['orange', 'blue', 'silver'] },
+    { name: 'Potomac Ave', slug: 'potomac-ave', lines: ['orange', 'blue', 'silver'] },
+    { name: 'Stadium-Armory', slug: 'stadium-armory', lines: ['orange', 'blue', 'silver'] },
+    { name: 'Minnesota Ave', slug: 'minnesota-ave', lines: ['orange'] },
+    { name: 'Deanwood', slug: 'deanwood', lines: ['orange'] },
+    { name: 'Cheverly', slug: 'cheverly', lines: ['orange'] },
+    { name: 'Landover', slug: 'landover', lines: ['orange'] },
+    { name: 'New Carrollton', slug: 'new-carrollton', lines: ['orange'] },
+    { name: 'Mt Vernon Sq 7th St-Convention Center', slug: 'mt-vernon-square', lines: ['yellow', 'green'] },
+    { name: 'Shaw-Howard U', slug: 'shaw-howard', lines: ['yellow', 'green'] },
+    { name: 'U Street/African-Amer Civil War Memorial/Cardozo', slug: 'u-street', lines: ['yellow', 'green'] },
+    { name: 'Columbia Heights', slug: 'columbia-heights', lines: ['yellow', 'green'] },
+    { name: 'Georgia Ave-Petworth', slug: 'georgia-ave-petworth', lines: ['yellow', 'green'] },
+    { name: 'West Hyattsville', slug: 'west-hyattsville', lines: ['yellow', 'green'] },
+    { name: "Prince George's Plaza", slug: 'prince-georges-plaza', lines: ['yellow', 'green'] },
+    { name: 'College Park-U of Md', slug: 'college-park', lines: ['yellow', 'green'] },
+    { name: 'Greenbelt', slug: 'greenbelt', lines: ['yellow', 'green'] },
+    { name: 'Archives-Navy Memorial-Penn Quarter', slug: 'archives', lines: ['yellow', 'green'] },
+    { name: 'Waterfront', slug: 'waterfront', lines: ['green'] },
+    { name: 'Navy Yard-Ballpark', slug: 'navy-yard', lines: ['green'] },
+    { name: 'Anacostia', slug: 'anacostia', lines: ['green'] },
+    { name: 'Congress Heights', slug: 'congress-heights', lines: ['green'] },
+    { name: 'Southern Ave', slug: 'southern-ave', lines: ['green'] },
+    { name: 'Naylor Road', slug: 'naylor-road', lines: ['green'] },
+    { name: 'Suitland', slug: 'suitland', lines: ['green'] },
+    { name: 'Branch Ave', slug: 'branch-ave', lines: ['green'] },
+    { name: 'Benning Road', slug: 'benning-road', lines: ['blue', 'silver'] },
+    { name: 'Capitol Heights', slug: 'capitol-heights', lines: ['blue', 'silver'] },
+    { name: 'Addison Road-Seat Pleasant', slug: 'addison-road', lines: ['blue', 'silver'] },
+    { name: 'Morgan Boulevard', slug: 'morgan-boulevard', lines: ['blue', 'silver'] },
+    { name: 'Largo Town Center', slug: 'largo-town-center', lines: ['blue', 'silver'] },
+    { name: 'Van Dorn Street', slug: 'van-dorn-street', lines: ['blue'] },
+    { name: 'Franconia-Springfield', slug: 'franconia-springfield', lines: ['blue'] },
+    { name: 'Court House', slug: 'court-house', lines: ['orange', 'silver'] },
+    { name: 'Clarendon', slug: 'clarendon', lines: ['orange', 'silver'] },
+    { name: 'Virginia Square-GMU', slug: 'virginia-square', lines: ['orange', 'silver'] },
+    { name: 'Ballston-MU', slug: 'ballston', lines: ['orange', 'silver'] },
+    { name: 'East Falls Church', slug: 'east-falls-church', lines: ['orange', 'silver'] },
+    { name: 'West Falls Church', slug: 'west-falls-church', lines: ['orange'] },
+    { name: 'Dunn Loring-Merrifield', slug: 'dunn-loring', lines: ['orange'] },
+    { name: 'Vienna/Fairfax-GMU', slug: 'vienna', lines: ['orange'] },
+    { name: 'McLean', slug: 'mclean', lines: ['silver'] },
+    { name: 'Tysons Corner', slug: 'tysons-corner', lines: ['silver'] },
+    { name: 'Greensboro', slug: 'greensboro', lines: ['silver'] },
+    { name: 'Spring Hill', slug: 'spring-hill', lines: ['silver'] },
+    { name: 'Wiehle-Reston East', slug: 'wiehle-reston-east', lines: ['silver'] },
+    { name: 'Reston Town Center', slug: 'reston-town-center', lines: ['silver'] },
+    { name: 'Herndon', slug: 'herndon', lines: ['silver'] },
+    { name: 'Innovation Center', slug: 'innovation-center', lines: ['silver'] },
+    { name: 'Dulles', slug: 'dulles', lines: ['silver'] },
+    { name: 'Loudon Gateway', slug: 'loudon-gateway', lines: ['silver'] },
+    { name: 'Ashburn', slug: 'ashburn', lines: ['silver'] },
+  ];
+
+  var searchLineColors = {
+    red: '#D41140',
+    orange: '#F09500',
+    blue: '#00A8E8',
+    yellow: '#FFD400',
+    green: '#00BD45',
+    silver: '#9BA5A5',
+  };
+
+  var input = document.getElementById('station-input');
+  var dropdown = document.getElementById('station-dropdown');
+  if (!input || !dropdown) return;
+
+  var highlighted = -1;
+
+  function filter(query) {
+    var q = query.toLowerCase().trim();
+    if (!q) return searchStations.slice(0, 8);
+    return searchStations.filter(function (s) {
+      return s.name.toLowerCase().indexOf(q) !== -1;
+    }).slice(0, 8);
+  }
+
+  function render(filtered) {
+    dropdown.innerHTML = '';
+    highlighted = -1;
+    if (filtered.length === 0) {
+      dropdown.classList.remove('open');
+      return;
+    }
+    filtered.forEach(function (station, i) {
+      var li = document.createElement('li');
+      var dots = document.createElement('span');
+      dots.className = 'line-dots';
+      station.lines.forEach(function (line) {
+        var dot = document.createElement('span');
+        dot.className = 'line-dot';
+        dot.style.backgroundColor = searchLineColors[line] || '#999';
+        dots.appendChild(dot);
+      });
+      li.appendChild(dots);
+      li.appendChild(document.createTextNode(station.name));
+      li.dataset.index = i;
+      li.addEventListener('click', function () {
+        window.location.href = '/station/' + station.slug + '/';
+      });
+      dropdown.appendChild(li);
+    });
+    dropdown.classList.add('open');
+  }
+
+  function highlight(items) {
+    for (var i = 0; i < items.length; i++) {
+      if (i === highlighted) {
+        items[i].classList.add('highlighted');
+        items[i].scrollIntoView({ block: 'nearest' });
+      } else {
+        items[i].classList.remove('highlighted');
+      }
+    }
+  }
+
+  input.addEventListener('input', function () {
+    render(filter(input.value));
+  });
+
+  input.addEventListener('focus', function () {
+    input.select();
+    render(filter(input.value));
+  });
+
+  input.addEventListener('keydown', function (e) {
+    var items = dropdown.querySelectorAll('li');
+    if (!items.length) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      highlighted = Math.min(highlighted + 1, items.length - 1);
+      highlight(items);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      highlighted = Math.max(highlighted - 1, 0);
+      highlight(items);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (highlighted >= 0 && items[highlighted]) {
+        items[highlighted].click();
+      }
+    } else if (e.key === 'Escape') {
+      dropdown.classList.remove('open');
+      input.blur();
+    }
+  });
+
+  document.addEventListener('click', function (e) {
+    if (!e.target.closest('#station-search-wrapper')) {
+      dropdown.classList.remove('open');
+    }
+  });
+})();

--- a/public/lines/blue/index.html
+++ b/public/lines/blue/index.html
@@ -267,6 +267,20 @@
 			<a href="/hours" class="mobile-menu-link">Hours</a>
 		</div>
 
+		<!-- Station Search -->
+		<div class="station-search" id="station-search-wrapper">
+			<i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+			<input
+				type="text"
+				id="station-input"
+				class="station-search__input"
+				placeholder="Search stations..."
+				autocomplete="off"
+				aria-label="Search for a Metro station"
+			/>
+			<ul class="station-dropdown" id="station-dropdown"></ul>
+		</div>
+
 		<!-- Line Hero -->
 		<section class="line-hero" data-line="blue">
 			<div class="line-hero__image">
@@ -1134,6 +1148,7 @@
 			</div>
 		</footer>
 		<script src="/js/nav.js"></script>
+		<script src="/js/search.js"></script>
 		<script>
 			window.LINE_CODE = 'BL';
 			window.LINE_NAME = 'Blue';

--- a/public/lines/blue/index.html
+++ b/public/lines/blue/index.html
@@ -272,6 +272,32 @@
 			<div class="ticker-track" id="ticker-track"></div>
 		</div>
 
+		<!-- Line Hero -->
+		<section class="line-hero" data-line="blue">
+			<div class="line-hero__image">
+				<img src="/images/julian-lozano.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
+			</div>
+			<div class="line-hero-inner">
+				<span class="line-hero-label">
+					<span class="line-hero-label-dot"></span>
+					Line
+				</span>
+				<div class="line-hero-bar"></div>
+				<h1 class="line-hero-title">Blue Line</h1>
+				<p class="line-hero-subtitle">
+					27 stations
+					<span class="line-hero-separator">&middot;</span>
+					Franconia-Springfield to Downtown Largo
+				</p>
+
+				<!-- Status Hero -->
+				<div class="line-status" id="line-status">
+					<span class="line-status-dot line-status-dot--loading" id="line-status-dot"></span>
+					<span class="line-status-text" id="line-status-text">Checking status...</span>
+				</div>
+			</div>
+		</section>
+
 		<main id="main-content" data-line="blue">
 			<nav class="nm-breadcrumb" aria-label="Breadcrumb">
 				<ol class="nm-breadcrumb-list">
@@ -280,32 +306,6 @@
 					<li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Blue Line</li>
 				</ol>
 			</nav>
-
-			<!-- Line Hero -->
-			<section class="line-hero">
-				<div class="line-hero__image">
-					<img src="/images/julian-lozano.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
-				</div>
-				<div class="line-hero-inner">
-					<span class="line-hero-label">
-						<span class="line-hero-label-dot"></span>
-						Line
-					</span>
-					<div class="line-hero-bar"></div>
-					<h1 class="line-hero-title">Blue Line</h1>
-					<p class="line-hero-subtitle">
-						27 stations
-						<span class="line-hero-separator">&middot;</span>
-						Franconia-Springfield to Downtown Largo
-					</p>
-
-					<!-- Status Hero -->
-					<div class="line-status" id="line-status">
-						<span class="line-status-dot line-status-dot--loading" id="line-status-dot"></span>
-						<span class="line-status-text" id="line-status-text">Checking status...</span>
-					</div>
-				</div>
-			</section>
 
 			<!-- Main Content -->
 			<div class="line-page">

--- a/public/lines/blue/index.html
+++ b/public/lines/blue/index.html
@@ -1060,6 +1060,7 @@
 						<a href="/elevators" class="nm-footer__link">Elevator Status</a>
 						<a href="/fares" class="nm-footer__link">Fares</a>
 						<a href="/hours" class="nm-footer__link">Hours</a>
+						<a href="/transfers" class="nm-footer__link">Transfers</a>
 					</nav>
 				</div>
 				<div class="nm-footer__col">

--- a/public/lines/blue/index.html
+++ b/public/lines/blue/index.html
@@ -267,11 +267,6 @@
 			<a href="/hours" class="mobile-menu-link">Hours</a>
 		</div>
 
-		<!-- Ticker placeholder -->
-		<div class="ticker-bar">
-			<div class="ticker-track" id="ticker-track"></div>
-		</div>
-
 		<!-- Line Hero -->
 		<section class="line-hero" data-line="blue">
 			<div class="line-hero__image">

--- a/public/lines/blue/index.html
+++ b/public/lines/blue/index.html
@@ -273,19 +273,19 @@
 		</div>
 
 		<main id="main-content" data-line="blue">
-			<!-- Breadcrumb -->
-			<nav class="line-breadcrumb" aria-label="Breadcrumb">
-				<ol class="line-breadcrumb-list">
-					<li class="line-breadcrumb-item"><a href="/">Home</a></li>
-					<li class="line-breadcrumb-separator" aria-hidden="true">/</li>
-					<li class="line-breadcrumb-item"><span>Metro Lines</span></li>
-					<li class="line-breadcrumb-separator" aria-hidden="true">/</li>
-					<li class="line-breadcrumb-item line-breadcrumb-current" aria-current="page">Blue Line</li>
+			<nav class="nm-breadcrumb" aria-label="Breadcrumb">
+				<ol class="nm-breadcrumb-list">
+					<li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+					<li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+					<li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Blue Line</li>
 				</ol>
 			</nav>
 
 			<!-- Line Hero -->
 			<section class="line-hero">
+				<div class="line-hero__image">
+					<img src="/images/julian-lozano.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
+				</div>
 				<div class="line-hero-inner">
 					<span class="line-hero-label">
 						<span class="line-hero-label-dot"></span>

--- a/public/lines/green/index.html
+++ b/public/lines/green/index.html
@@ -237,6 +237,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Line Hero -->
   <section class="line-hero" data-line="green">
     <div class="line-hero__image">
@@ -588,6 +602,7 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
   <script>window.LINE_CODE='GR';window.LINE_NAME='Green';</script>
   <script src="/js/shared.js"></script>
   <script src="/js/line.js"></script>

--- a/public/lines/green/index.html
+++ b/public/lines/green/index.html
@@ -242,17 +242,8 @@
     <div class="ticker-track" id="ticker-track"></div>
   </div>
 
-  <main id="main-content" data-line="green">
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Green Line</li>
-    </ol>
-  </nav>
-
   <!-- Line Hero -->
-  <section class="line-hero">
+  <section class="line-hero" data-line="green">
     <div class="line-hero__image">
       <img src="/images/island-cinematics.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
     </div>
@@ -269,6 +260,15 @@
       </div>
     </div>
   </section>
+
+  <main id="main-content" data-line="green">
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Green Line</li>
+    </ol>
+  </nav>
 
   <!-- Main Content -->
   <div class="line-page">

--- a/public/lines/green/index.html
+++ b/public/lines/green/index.html
@@ -533,6 +533,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/lines/green/index.html
+++ b/public/lines/green/index.html
@@ -237,11 +237,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar">
-    <div class="ticker-track" id="ticker-track"></div>
-  </div>
-
   <!-- Line Hero -->
   <section class="line-hero" data-line="green">
     <div class="line-hero__image">

--- a/public/lines/green/index.html
+++ b/public/lines/green/index.html
@@ -243,19 +243,19 @@
   </div>
 
   <main id="main-content" data-line="green">
-  <!-- Breadcrumb -->
-  <nav class="line-breadcrumb" aria-label="Breadcrumb">
-    <ol class="line-breadcrumb-list">
-      <li class="line-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="line-breadcrumb-separator" aria-hidden="true">/</li>
-      <li class="line-breadcrumb-item"><span>Metro Lines</span></li>
-      <li class="line-breadcrumb-separator" aria-hidden="true">/</li>
-      <li class="line-breadcrumb-item line-breadcrumb-current" aria-current="page">Green Line</li>
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Green Line</li>
     </ol>
   </nav>
 
   <!-- Line Hero -->
   <section class="line-hero">
+    <div class="line-hero__image">
+      <img src="/images/island-cinematics.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
+    </div>
     <div class="line-hero-inner">
       <span class="line-hero-label"><span class="line-hero-label-dot"></span>Line</span>
       <div class="line-hero-bar"></div>

--- a/public/lines/orange/index.html
+++ b/public/lines/orange/index.html
@@ -237,11 +237,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar">
-    <div class="ticker-track" id="ticker-track"></div>
-  </div>
-
   <!-- Line Hero -->
   <section class="line-hero" data-line="orange">
     <div class="line-hero__image">

--- a/public/lines/orange/index.html
+++ b/public/lines/orange/index.html
@@ -243,19 +243,19 @@
   </div>
 
   <main id="main-content" data-line="orange">
-  <!-- Breadcrumb -->
-  <nav class="line-breadcrumb" aria-label="Breadcrumb">
-    <ol class="line-breadcrumb-list">
-      <li class="line-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="line-breadcrumb-separator" aria-hidden="true">/</li>
-      <li class="line-breadcrumb-item"><span>Metro Lines</span></li>
-      <li class="line-breadcrumb-separator" aria-hidden="true">/</li>
-      <li class="line-breadcrumb-item line-breadcrumb-current" aria-current="page">Orange Line</li>
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Orange Line</li>
     </ol>
   </nav>
 
   <!-- Line Hero -->
   <section class="line-hero">
+    <div class="line-hero__image">
+      <img src="/images/maria-oswalt.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
+    </div>
     <div class="line-hero-inner">
       <span class="line-hero-label"><span class="line-hero-label-dot"></span>Line</span>
       <div class="line-hero-bar"></div>

--- a/public/lines/orange/index.html
+++ b/public/lines/orange/index.html
@@ -538,6 +538,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/lines/orange/index.html
+++ b/public/lines/orange/index.html
@@ -242,17 +242,8 @@
     <div class="ticker-track" id="ticker-track"></div>
   </div>
 
-  <main id="main-content" data-line="orange">
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Orange Line</li>
-    </ol>
-  </nav>
-
   <!-- Line Hero -->
-  <section class="line-hero">
+  <section class="line-hero" data-line="orange">
     <div class="line-hero__image">
       <img src="/images/maria-oswalt.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
     </div>
@@ -269,6 +260,15 @@
       </div>
     </div>
   </section>
+
+  <main id="main-content" data-line="orange">
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Orange Line</li>
+    </ol>
+  </nav>
 
   <!-- Main Content -->
   <div class="line-page">

--- a/public/lines/orange/index.html
+++ b/public/lines/orange/index.html
@@ -237,6 +237,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Line Hero -->
   <section class="line-hero" data-line="orange">
     <div class="line-hero__image">
@@ -593,6 +607,7 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
   <script>window.LINE_CODE='OR';window.LINE_NAME='Orange';</script>
   <script src="/js/shared.js"></script>
   <script src="/js/line.js"></script>

--- a/public/lines/red/index.html
+++ b/public/lines/red/index.html
@@ -237,6 +237,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Line Hero -->
   <section class="line-hero" data-line="red">
     <div class="line-hero__image">
@@ -594,6 +608,7 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
   <script>window.LINE_CODE='RD';window.LINE_NAME='Red';</script>
   <script src="/js/shared.js"></script>
   <script src="/js/line.js"></script>

--- a/public/lines/red/index.html
+++ b/public/lines/red/index.html
@@ -242,17 +242,8 @@
     <div class="ticker-track" id="ticker-track"></div>
   </div>
 
-  <main id="main-content" data-line="red">
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Red Line</li>
-    </ol>
-  </nav>
-
   <!-- Line Hero -->
-  <section class="line-hero">
+  <section class="line-hero" data-line="red">
     <div class="line-hero__image">
       <img src="/images/chris-grafton.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
     </div>
@@ -269,6 +260,15 @@
       </div>
     </div>
   </section>
+
+  <main id="main-content" data-line="red">
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Red Line</li>
+    </ol>
+  </nav>
 
   <!-- Main Content -->
   <div class="line-page">

--- a/public/lines/red/index.html
+++ b/public/lines/red/index.html
@@ -539,6 +539,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/lines/red/index.html
+++ b/public/lines/red/index.html
@@ -237,11 +237,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar">
-    <div class="ticker-track" id="ticker-track"></div>
-  </div>
-
   <!-- Line Hero -->
   <section class="line-hero" data-line="red">
     <div class="line-hero__image">

--- a/public/lines/red/index.html
+++ b/public/lines/red/index.html
@@ -243,19 +243,19 @@
   </div>
 
   <main id="main-content" data-line="red">
-  <!-- Breadcrumb -->
-  <nav class="line-breadcrumb" aria-label="Breadcrumb">
-    <ol class="line-breadcrumb-list">
-      <li class="line-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="line-breadcrumb-separator" aria-hidden="true">/</li>
-      <li class="line-breadcrumb-item"><span>Metro Lines</span></li>
-      <li class="line-breadcrumb-separator" aria-hidden="true">/</li>
-      <li class="line-breadcrumb-item line-breadcrumb-current" aria-current="page">Red Line</li>
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Red Line</li>
     </ol>
   </nav>
 
   <!-- Line Hero -->
   <section class="line-hero">
+    <div class="line-hero__image">
+      <img src="/images/chris-grafton.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
+    </div>
     <div class="line-hero-inner">
       <span class="line-hero-label"><span class="line-hero-label-dot"></span>Line</span>
       <div class="line-hero-bar"></div>

--- a/public/lines/silver/index.html
+++ b/public/lines/silver/index.html
@@ -546,6 +546,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/lines/silver/index.html
+++ b/public/lines/silver/index.html
@@ -237,11 +237,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar">
-    <div class="ticker-track" id="ticker-track"></div>
-  </div>
-
   <!-- Line Hero -->
   <section class="line-hero" data-line="silver">
     <div class="line-hero__image">

--- a/public/lines/silver/index.html
+++ b/public/lines/silver/index.html
@@ -242,17 +242,8 @@
     <div class="ticker-track" id="ticker-track"></div>
   </div>
 
-  <main id="main-content" data-line="silver">
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Silver Line</li>
-    </ol>
-  </nav>
-
   <!-- Line Hero -->
-  <section class="line-hero">
+  <section class="line-hero" data-line="silver">
     <div class="line-hero__image">
       <img src="/images/tatiana-rodriguez.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
     </div>
@@ -269,6 +260,15 @@
       </div>
     </div>
   </section>
+
+  <main id="main-content" data-line="silver">
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Silver Line</li>
+    </ol>
+  </nav>
 
   <!-- Main Content -->
   <div class="line-page">

--- a/public/lines/silver/index.html
+++ b/public/lines/silver/index.html
@@ -243,19 +243,19 @@
   </div>
 
   <main id="main-content" data-line="silver">
-  <!-- Breadcrumb -->
-  <nav class="line-breadcrumb" aria-label="Breadcrumb">
-    <ol class="line-breadcrumb-list">
-      <li class="line-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="line-breadcrumb-separator" aria-hidden="true">/</li>
-      <li class="line-breadcrumb-item"><span>Metro Lines</span></li>
-      <li class="line-breadcrumb-separator" aria-hidden="true">/</li>
-      <li class="line-breadcrumb-item line-breadcrumb-current" aria-current="page">Silver Line</li>
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Silver Line</li>
     </ol>
   </nav>
 
   <!-- Line Hero -->
   <section class="line-hero">
+    <div class="line-hero__image">
+      <img src="/images/tatiana-rodriguez.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
+    </div>
     <div class="line-hero-inner">
       <span class="line-hero-label"><span class="line-hero-label-dot"></span>Line</span>
       <div class="line-hero-bar"></div>

--- a/public/lines/silver/index.html
+++ b/public/lines/silver/index.html
@@ -237,6 +237,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Line Hero -->
   <section class="line-hero" data-line="silver">
     <div class="line-hero__image">
@@ -601,6 +615,7 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
   <script>window.LINE_CODE='SV';window.LINE_NAME='Silver';</script>
   <script src="/js/shared.js"></script>
   <script src="/js/line.js"></script>

--- a/public/lines/yellow/index.html
+++ b/public/lines/yellow/index.html
@@ -242,17 +242,8 @@
     <div class="ticker-track" id="ticker-track"></div>
   </div>
 
-  <main id="main-content" data-line="yellow">
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Yellow Line</li>
-    </ol>
-  </nav>
-
   <!-- Line Hero -->
-  <section class="line-hero">
+  <section class="line-hero" data-line="yellow">
     <div class="line-hero__image">
       <img src="/images/andrew-wagner.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
     </div>
@@ -269,6 +260,15 @@
       </div>
     </div>
   </section>
+
+  <main id="main-content" data-line="yellow">
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Yellow Line</li>
+    </ol>
+  </nav>
 
   <!-- Main Content -->
   <div class="line-page">

--- a/public/lines/yellow/index.html
+++ b/public/lines/yellow/index.html
@@ -243,19 +243,19 @@
   </div>
 
   <main id="main-content" data-line="yellow">
-  <!-- Breadcrumb -->
-  <nav class="line-breadcrumb" aria-label="Breadcrumb">
-    <ol class="line-breadcrumb-list">
-      <li class="line-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="line-breadcrumb-separator" aria-hidden="true">/</li>
-      <li class="line-breadcrumb-item"><span>Metro Lines</span></li>
-      <li class="line-breadcrumb-separator" aria-hidden="true">/</li>
-      <li class="line-breadcrumb-item line-breadcrumb-current" aria-current="page">Yellow Line</li>
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Yellow Line</li>
     </ol>
   </nav>
 
   <!-- Line Hero -->
   <section class="line-hero">
+    <div class="line-hero__image">
+      <img src="/images/andrew-wagner.jpg" alt="" loading="eager" onerror="this.dataset.error=true" />
+    </div>
     <div class="line-hero-inner">
       <span class="line-hero-label"><span class="line-hero-label-dot"></span>Line</span>
       <div class="line-hero-bar"></div>

--- a/public/lines/yellow/index.html
+++ b/public/lines/yellow/index.html
@@ -237,11 +237,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar">
-    <div class="ticker-track" id="ticker-track"></div>
-  </div>
-
   <!-- Line Hero -->
   <section class="line-hero" data-line="yellow">
     <div class="line-hero__image">

--- a/public/lines/yellow/index.html
+++ b/public/lines/yellow/index.html
@@ -533,6 +533,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/lines/yellow/index.html
+++ b/public/lines/yellow/index.html
@@ -237,6 +237,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Line Hero -->
   <section class="line-hero" data-line="yellow">
     <div class="line-hero__image">
@@ -588,6 +602,7 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
   <script>window.LINE_CODE='YL';window.LINE_NAME='Yellow';</script>
   <script src="/js/shared.js"></script>
   <script src="/js/line.js"></script>

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -608,6 +608,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -78,11 +78,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar" role="marquee" aria-label="Metro line status">
-    <div class="ticker-track"></div>
-  </div>
-
   <!-- Privacy Policy Content -->
   <main id="main-content">
   <div class="legal-page">

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -78,6 +78,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Privacy Policy Content -->
   <main id="main-content">
   <div class="legal-page">
@@ -663,5 +677,6 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
 </body>
 </html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -32,6 +32,11 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://nextmetro.live/transfers/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://nextmetro.live/about/</loc>
     <lastmod>2026-03-14</lastmod>
     <changefreq>monthly</changefreq>

--- a/public/station/brookland-cua/index.html
+++ b/public/station/brookland-cua/index.html
@@ -221,16 +221,19 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Brookland-CUA</li>
+    </ol>
+  </nav>
+
   <!-- Hero / Station Selector -->
   <section class="hero" id="hero">
     <div class="hero-inner">
-      <nav class="hero-breadcrumb" aria-label="Breadcrumb">
-        <a href="/">Home</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <a href="/lines/red/">Red Line</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <span class="hero-breadcrumb__current">Brookland-CUA</span>
-      </nav>
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">Brookland-CUA</h1>
       <p class="hero-station-desc" id="hero-station-desc">Servicing Brookland, Edgewood &amp; Catholic University of America.</p>

--- a/public/station/brookland-cua/index.html
+++ b/public/station/brookland-cua/index.html
@@ -514,6 +514,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/station/brookland-cua/index.html
+++ b/public/station/brookland-cua/index.html
@@ -221,16 +221,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Brookland-CUA</li>
-    </ol>
-  </nav>
-
   <!-- Hero / Station Selector -->
   <section class="hero" id="hero">
     <div class="hero-inner">
@@ -242,6 +232,16 @@
       <div class="line-pills" id="line-pills"></div>
     </div>
   </section>
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Brookland-CUA</li>
+    </ol>
+  </nav>
 
   <!-- Station Search -->
   <div class="station-search" id="station-search-wrapper">

--- a/public/station/gallery-place/index.html
+++ b/public/station/gallery-place/index.html
@@ -152,16 +152,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item"><a href="/transfers/">Transfer Stations</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Gallery Pl-Chinatown</li>
-    </ol>
-  </nav>
-
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
@@ -177,6 +167,16 @@
       <div class="line-pills" id="line-pills"></div>
     </div>
   </section>
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/transfers/">Transfer Stations</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Gallery Pl-Chinatown</li>
+    </ol>
+  </nav>
 
   <!-- Station Search -->
   <div class="station-search" id="station-search-wrapper">

--- a/public/station/gallery-place/index.html
+++ b/public/station/gallery-place/index.html
@@ -435,6 +435,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares" class="nm-footer__link">Fares</a>
           <a href="/hours" class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/station/gallery-place/index.html
+++ b/public/station/gallery-place/index.html
@@ -152,19 +152,22 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/transfers/">Transfer Stations</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Gallery Pl-Chinatown</li>
+    </ol>
+  </nav>
+
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
       <img src="/images/station-specific/gallery-place-chinatown/gallery-place-chinatown-00.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
     </div>
     <div class="hero-inner">
-      <nav class="hero-breadcrumb" aria-label="Breadcrumb">
-        <a href="/">Home</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <a href="/lines/red/">Red Line</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <span class="hero-breadcrumb__current">Gallery Pl-Chinatown</span>
-      </nav>
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">Gallery Pl-Chinatown</h1>
       <p class="hero-station-desc" id="hero-station-desc">Chinatown, Penn Quarter &amp; Capital One Arena.</p>

--- a/public/station/judiciary-square/index.html
+++ b/public/station/judiciary-square/index.html
@@ -151,19 +151,22 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Judiciary Square</li>
+    </ol>
+  </nav>
+
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
       <img src="/images/station-specific/judiciary-square-station.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
     </div>
     <div class="hero-inner">
-      <nav class="hero-breadcrumb" aria-label="Breadcrumb">
-        <a href="/">Home</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <a href="/lines/red/">Red Line</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <span class="hero-breadcrumb__current">Judiciary Square</span>
-      </nav>
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">Judiciary Square</h1>
       <p class="hero-station-desc" id="hero-station-desc">Servicing Judiciary Square &amp; the National Building Museum.</p>

--- a/public/station/judiciary-square/index.html
+++ b/public/station/judiciary-square/index.html
@@ -151,16 +151,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Judiciary Square</li>
-    </ol>
-  </nav>
-
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
@@ -175,6 +165,16 @@
       <div class="line-pills" id="line-pills"></div>
     </div>
   </section>
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Judiciary Square</li>
+    </ol>
+  </nav>
 
   <!-- Station Search -->
   <div class="station-search" id="station-search-wrapper">

--- a/public/station/judiciary-square/index.html
+++ b/public/station/judiciary-square/index.html
@@ -380,6 +380,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares" class="nm-footer__link">Fares</a>
           <a href="/hours" class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/station/lenfant-plaza/index.html
+++ b/public/station/lenfant-plaza/index.html
@@ -439,6 +439,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares" class="nm-footer__link">Fares</a>
           <a href="/hours" class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/station/lenfant-plaza/index.html
+++ b/public/station/lenfant-plaza/index.html
@@ -152,16 +152,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item"><a href="/transfers/">Transfer Stations</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">L&#39;Enfant Plaza</li>
-    </ol>
-  </nav>
-
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
@@ -177,6 +167,16 @@
       <div class="line-pills" id="line-pills"></div>
     </div>
   </section>
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/transfers/">Transfer Stations</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">L&#39;Enfant Plaza</li>
+    </ol>
+  </nav>
 
   <!-- Station Search -->
   <div class="station-search" id="station-search-wrapper">

--- a/public/station/lenfant-plaza/index.html
+++ b/public/station/lenfant-plaza/index.html
@@ -152,19 +152,22 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/transfers/">Transfer Stations</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">L&#39;Enfant Plaza</li>
+    </ol>
+  </nav>
+
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
       <img src="/images/station-specific/l-enfant-plaza/l-enfant-plaza-metro-station-00.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
     </div>
     <div class="hero-inner">
-      <nav class="hero-breadcrumb" aria-label="Breadcrumb">
-        <a href="/">Home</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <a href="/lines/orange/">Orange Line</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <span class="hero-breadcrumb__current">L'Enfant Plaza</span>
-      </nav>
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">L'Enfant Plaza</h1>
       <p class="hero-station-desc" id="hero-station-desc">Southwest Waterfront hub — Or, Bl, Sv, Gr &amp; Yl Lines.</p>

--- a/public/station/metro-center/index.html
+++ b/public/station/metro-center/index.html
@@ -572,6 +572,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/station/metro-center/index.html
+++ b/public/station/metro-center/index.html
@@ -213,16 +213,19 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/transfers/">Transfer Stations</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Metro Center</li>
+    </ol>
+  </nav>
+
   <!-- Hero / Station Header -->
   <section class="hero" id="hero">
     <div class="hero-inner">
-      <nav class="hero-breadcrumb" aria-label="Breadcrumb">
-        <a href="/">Home</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <a href="/lines/red/">Red Line</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <span class="hero-breadcrumb__current">Metro Center</span>
-      </nav>
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">Metro Center</h1>
       <p class="hero-station-desc" id="hero-station-desc">Downtown DC's central hub — Red, Orange, Blue &amp; Silver Lines.</p>

--- a/public/station/metro-center/index.html
+++ b/public/station/metro-center/index.html
@@ -213,16 +213,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item"><a href="/transfers/">Transfer Stations</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Metro Center</li>
-    </ol>
-  </nav>
-
   <!-- Hero / Station Header -->
   <section class="hero" id="hero">
     <div class="hero-inner">
@@ -235,6 +225,16 @@
       <div class="line-pills" id="line-pills"></div>
     </div>
   </section>
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/transfers/">Transfer Stations</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Metro Center</li>
+    </ol>
+  </nav>
 
   <!-- Station Search -->
   <div class="station-search" id="station-search-wrapper">

--- a/public/station/noma/index.html
+++ b/public/station/noma/index.html
@@ -151,19 +151,22 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">NoMa-Gallaudet U</li>
+    </ol>
+  </nav>
+
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
       <img src="/images/station-specific/noma-gallaudet-u.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
     </div>
     <div class="hero-inner">
-      <nav class="hero-breadcrumb" aria-label="Breadcrumb">
-        <a href="/">Home</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <a href="/lines/red/">Red Line</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <span class="hero-breadcrumb__current">NoMa-Gallaudet U</span>
-      </nav>
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">NoMa-Gallaudet U</h1>
       <p class="hero-station-desc" id="hero-station-desc">Servicing NoMa &amp; Gallaudet University.</p>

--- a/public/station/noma/index.html
+++ b/public/station/noma/index.html
@@ -151,16 +151,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">NoMa-Gallaudet U</li>
-    </ol>
-  </nav>
-
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
@@ -175,6 +165,16 @@
       <div class="line-pills" id="line-pills"></div>
     </div>
   </section>
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">NoMa-Gallaudet U</li>
+    </ol>
+  </nav>
 
   <!-- Station Search -->
   <div class="station-search" id="station-search-wrapper">

--- a/public/station/noma/index.html
+++ b/public/station/noma/index.html
@@ -380,6 +380,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares" class="nm-footer__link">Fares</a>
           <a href="/hours" class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/station/potomac-yard/index.html
+++ b/public/station/potomac-yard/index.html
@@ -217,16 +217,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item"><a href="/lines/blue/">Blue Line</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Potomac Yard</li>
-    </ol>
-  </nav>
-
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
@@ -241,6 +231,16 @@
       <div class="line-pills" id="line-pills"></div>
     </div>
   </section>
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/blue/">Blue Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Potomac Yard</li>
+    </ol>
+  </nav>
 
   <!-- Station Search -->
   <div class="station-search" id="station-search-wrapper">

--- a/public/station/potomac-yard/index.html
+++ b/public/station/potomac-yard/index.html
@@ -517,6 +517,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/station/potomac-yard/index.html
+++ b/public/station/potomac-yard/index.html
@@ -217,19 +217,22 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/blue/">Blue Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Potomac Yard</li>
+    </ol>
+  </nav>
+
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
       <img src="/images/station-specific/potomac-yard-vt.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
     </div>
     <div class="hero-inner">
-      <nav class="hero-breadcrumb" aria-label="Breadcrumb">
-        <a href="/">Home</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <a href="/lines/blue/">Blue Line</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <span class="hero-breadcrumb__current">Potomac Yard</span>
-      </nav>
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">Potomac Yard</h1>
       <p class="hero-station-desc" id="hero-station-desc">WMATA's newest station, servicing Potomac Yard &amp; North Alexandria.</p>

--- a/public/station/smithsonian/index.html
+++ b/public/station/smithsonian/index.html
@@ -151,19 +151,22 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/orange/">Orange Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Smithsonian</li>
+    </ol>
+  </nav>
+
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
       <img src="/images/station-specific/smithsonian-station-escalator.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
     </div>
     <div class="hero-inner">
-      <nav class="hero-breadcrumb" aria-label="Breadcrumb">
-        <a href="/">Home</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <a href="/lines/orange/">Orange Line</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <span class="hero-breadcrumb__current">Smithsonian</span>
-      </nav>
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">Smithsonian</h1>
       <p class="hero-station-desc" id="hero-station-desc">Servicing the National Mall &amp; Smithsonian museums.</p>

--- a/public/station/smithsonian/index.html
+++ b/public/station/smithsonian/index.html
@@ -151,16 +151,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item"><a href="/lines/orange/">Orange Line</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Smithsonian</li>
-    </ol>
-  </nav>
-
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
@@ -175,6 +165,16 @@
       <div class="line-pills" id="line-pills"></div>
     </div>
   </section>
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/orange/">Orange Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Smithsonian</li>
+    </ol>
+  </nav>
 
   <!-- Station Search -->
   <div class="station-search" id="station-search-wrapper">

--- a/public/station/smithsonian/index.html
+++ b/public/station/smithsonian/index.html
@@ -382,6 +382,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares" class="nm-footer__link">Fares</a>
           <a href="/hours" class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/station/union-station/index.html
+++ b/public/station/union-station/index.html
@@ -403,6 +403,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares" class="nm-footer__link">Fares</a>
           <a href="/hours" class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/station/union-station/index.html
+++ b/public/station/union-station/index.html
@@ -160,16 +160,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Union Station</li>
-    </ol>
-  </nav>
-
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
@@ -184,6 +174,16 @@
       <div class="line-pills" id="line-pills"></div>
     </div>
   </section>
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Union Station</li>
+    </ol>
+  </nav>
 
   <!-- Station Search -->
   <div class="station-search" id="station-search-wrapper">

--- a/public/station/union-station/index.html
+++ b/public/station/union-station/index.html
@@ -160,19 +160,22 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Union Station</li>
+    </ol>
+  </nav>
+
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
       <img src="/images/station-specific/union-station.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
     </div>
     <div class="hero-inner">
-      <nav class="hero-breadcrumb" aria-label="Breadcrumb">
-        <a href="/">Home</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <a href="/lines/red/">Red Line</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <span class="hero-breadcrumb__current">Union Station</span>
-      </nav>
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">Union Station</h1>
       <p class="hero-station-desc" id="hero-station-desc">Capitol Hill's transit hub — Amtrak, MARC, VRE &amp; Metro Red Line.</p>

--- a/public/station/van-ness-udc/index.html
+++ b/public/station/van-ness-udc/index.html
@@ -151,19 +151,22 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Van Ness-UDC</li>
+    </ol>
+  </nav>
+
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
       <img src="/images/station-specific/van-ness-udc-station-platform.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
     </div>
     <div class="hero-inner">
-      <nav class="hero-breadcrumb" aria-label="Breadcrumb">
-        <a href="/">Home</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <a href="/lines/red/">Red Line</a>
-        <span class="hero-breadcrumb__sep" aria-hidden="true">/</span>
-        <span class="hero-breadcrumb__current">Van Ness-UDC</span>
-      </nav>
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">Van Ness-UDC</h1>
       <p class="hero-station-desc" id="hero-station-desc">Servicing Van Ness &amp; University of the District of Columbia.</p>

--- a/public/station/van-ness-udc/index.html
+++ b/public/station/van-ness-udc/index.html
@@ -151,16 +151,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </div>
 
-  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
-    <ol class="nm-breadcrumb-list">
-      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
-      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
-      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Van Ness-UDC</li>
-    </ol>
-  </nav>
-
   <!-- Hero / Station Header -->
   <section class="hero hero--has-image" id="hero">
     <div class="hero__image" aria-hidden="true">
@@ -175,6 +165,16 @@
       <div class="line-pills" id="line-pills"></div>
     </div>
   </section>
+
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item"><a href="/lines/red/">Red Line</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Van Ness-UDC</li>
+    </ol>
+  </nav>
 
   <!-- Station Search -->
   <div class="station-search" id="station-search-wrapper">

--- a/public/station/van-ness-udc/index.html
+++ b/public/station/van-ness-udc/index.html
@@ -380,6 +380,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares" class="nm-footer__link">Fares</a>
           <a href="/hours" class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/terms/index.html
+++ b/public/terms/index.html
@@ -78,11 +78,6 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar" role="marquee" aria-label="Metro line status">
-    <div class="ticker-track"></div>
-  </div>
-
   <!-- Terms of Service Content -->
   <main id="main-content">
   <div class="legal-page">

--- a/public/terms/index.html
+++ b/public/terms/index.html
@@ -78,6 +78,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Terms of Service Content -->
   <main id="main-content">
   <div class="legal-page">
@@ -422,5 +436,6 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
 </body>
 </html>

--- a/public/terms/index.html
+++ b/public/terms/index.html
@@ -367,6 +367,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/transfers/index.html
+++ b/public/transfers/index.html
@@ -8,6 +8,7 @@
   <link rel="canonical" href="https://nextmetro.live/transfers/" />
   <link rel="stylesheet" href="/css/styles.css" />
   <link rel="stylesheet" href="/css/line.css" />
+  <link rel="stylesheet" href="/css/transfers.css" />
   <link rel="stylesheet" href="/css/nav.css" />
   <link rel="stylesheet" href="/css/footer.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -176,11 +177,6 @@
     <a href="/fares" class="mobile-menu-link">Fares</a>
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
-
-  <!-- Ticker placeholder -->
-  <div class="ticker-bar" role="marquee" aria-label="Metro line status">
-    <div class="ticker-track"></div>
-  </div>
 
   <!-- Transfers Hero -->
   <section class="transfers-hero">

--- a/public/transfers/index.html
+++ b/public/transfers/index.html
@@ -1,0 +1,511 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DC Metro Transfer Stations — Where to Change Lines | NextMetro</title>
+  <meta name="description" content="Complete guide to DC Metro transfer stations. Find where to change lines at Metro Center, Gallery Place-Chinatown, L'Enfant Plaza, and Fort Totten. Includes walking transfers and platform info." />
+  <link rel="canonical" href="https://nextmetro.live/transfers/" />
+  <link rel="stylesheet" href="/css/styles.css" />
+  <link rel="stylesheet" href="/css/line.css" />
+  <link rel="stylesheet" href="/css/nav.css" />
+  <link rel="stylesheet" href="/css/footer.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/remixicon@4.6.0/fonts/remixicon.css" rel="stylesheet" integrity="sha256-MblAFgCXnFAJlRJnqJqOjRfz0ODAP+6LxfGQEK7g1o=" crossorigin="anonymous" />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="DC Metro Transfer Stations — Where to Change Lines | NextMetro" />
+  <meta property="og:description" content="Complete guide to DC Metro transfer stations. Find where to change lines at Metro Center, Gallery Place, L'Enfant Plaza, and Fort Totten." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://nextmetro.live/transfers/" />
+  <meta property="og:site_name" content="NextMetro" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:image" content="https://nextmetro.live/images/og/homepage-utility/og-transfers.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="DC Metro Transfer Stations — NextMetro" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="DC Metro Transfer Stations — Where to Change Lines | NextMetro" />
+  <meta name="twitter:description" content="Complete guide to DC Metro transfer stations. Find where to change lines at Metro Center, Gallery Place, L'Enfant Plaza, and Fort Totten." />
+  <meta name="twitter:image" content="https://nextmetro.live/images/og/homepage-utility/og-transfers.png" />
+
+  <!-- Favicon -->
+  <link rel="icon" href="/favicon.ico" sizes="48x48" />
+  <link rel="icon" href="/images/icons/nm-mark.svg" type="image/svg+xml" />
+  <link rel="icon" href="/images/icons/favicon-32x32.png" sizes="32x32" type="image/png" />
+  <link rel="icon" href="/images/icons/favicon-16x16.png" sizes="16x16" type="image/png" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <meta name="theme-color" content="#0A0A0A" />
+
+  <!-- BreadcrumbList Schema -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "https://nextmetro.live/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Transfer Stations",
+        "item": "https://nextmetro.live/transfers/"
+      }
+    ]
+  }
+  </script>
+
+  <!-- FAQ Schema -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What are the DC Metro transfer stations?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The DC Metro has four in-system transfer stations where passengers can switch between lines without leaving the station: Metro Center (Red, Orange, Blue, Silver), Gallery Place-Chinatown (Red, Green, Yellow), L'Enfant Plaza (Orange, Blue, Silver, Green, Yellow), and Fort Totten (Red, Green, Yellow). There is also a free walking transfer between Farragut North (Red) and Farragut West (Orange, Blue, Silver)."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I transfer at Metro Center?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Metro Center has two platforms connected by escalators and elevators. Platform A serves the Red Line (Shady Grove and Glenmont directions), while Platform B serves the Orange, Blue, and Silver Lines. Follow signs for your destination line when transferring. The transfer is free and included in your fare."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is there an extra charge to transfer between Metro lines?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "No. Transferring between Metrorail lines is free and included in your fare. You do not need to tap out and back in — simply follow the signs to the other platform within the station. Your fare is calculated based on your origin and final destination, regardless of how many lines you use during your trip."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which Metro lines connect at Gallery Place-Chinatown?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Gallery Place-Chinatown connects the Red Line with the Green and Yellow Lines. The upper platform serves the Red Line, while the lower platform serves the Green and Yellow Lines. The station is located in downtown DC near Capital One Arena."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the Farragut walking transfer?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The Farragut walking transfer allows passengers to exit at Farragut North (Red Line) and walk one block to Farragut West (Orange, Blue, Silver Lines), or vice versa, without paying an additional fare. You must tap out at one station and tap in at the other within 30 minutes for the transfer to be free. This is the only free out-of-station transfer in the Metro system."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I get from the Red Line to the Green or Yellow Line?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "You can transfer from the Red Line to the Green or Yellow Line at two stations: Gallery Place-Chinatown (downtown DC, near Capital One Arena) or Fort Totten (northeast DC/Maryland border). At Gallery Place, take the escalators between the upper Red Line platform and the lower Green/Yellow platform. At Fort Totten, the transfer is cross-platform on the same level."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which station connects the most Metro lines?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "L'Enfant Plaza connects the most Metro lines — five of the six lines stop there: Orange, Blue, Silver, Green, and Yellow. The only line that does not serve L'Enfant Plaza is the Red Line. It is the busiest transfer station in the system and is located near the National Mall, Smithsonian museums, and several federal agencies."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How long does it take to transfer between platforms?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "In-station transfers typically take 2 to 5 minutes, depending on the station layout and whether you need to use escalators or elevators. At Metro Center and Gallery Place, you'll ride escalators between levels. At Fort Totten, the transfer is cross-platform (same level). The Farragut walking transfer takes about 5 to 10 minutes on foot between the two stations."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- NextMetro Site Nav -->
+  <nav class="nm-nav" aria-label="Site navigation">
+    <div class="nm-nav__strip" aria-hidden="true">
+      <span></span>
+      <span></span>
+      <span></span>
+      <span></span>
+      <span></span>
+      <span></span>
+    </div>
+    <a href="/" class="nm-nav__logo" aria-label="NextMetro home">
+      <span class="nm-nav__logo-next">NEXT</span>
+      <span class="nm-nav__logo-divider" aria-hidden="true"></span>
+      <span class="nm-nav__logo-metro">METRO</span>
+    </a>
+    <div class="nm-nav__links">
+      <a href="/alerts" class="nm-nav__link">Alerts</a>
+      <a href="https://wmata.com/schedules/maps/upload/system-map-rail.pdf" class="nm-nav__link" target="_blank" rel="noopener noreferrer" title="System Map (PDF, opens in new tab)" aria-label="System Map (PDF, opens in new tab)">Map</a>
+      <a href="/fares" class="nm-nav__link">Fares</a>
+      <a href="/hours" class="nm-nav__link">Hours</a>
+    </div>
+    <button class="nm-nav__hamburger" id="navbar-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-menu">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+  </nav>
+  <nav class="nm-mobile-menu" id="mobile-menu" aria-label="Mobile navigation">
+    <a href="/alerts" class="mobile-menu-link">Alerts</a>
+    <a href="https://wmata.com/schedules/maps/upload/system-map-rail.pdf" class="mobile-menu-link" target="_blank" rel="noopener noreferrer" title="System Map (PDF, opens in new tab)" aria-label="System Map (PDF, opens in new tab)">Map</a>
+    <a href="/fares" class="mobile-menu-link">Fares</a>
+    <a href="/hours" class="mobile-menu-link">Hours</a>
+  </nav>
+
+  <!-- Ticker placeholder -->
+  <div class="ticker-bar" role="marquee" aria-label="Metro line status">
+    <div class="ticker-track"></div>
+  </div>
+
+  <main id="main-content">
+  <!-- Breadcrumb -->
+  <nav class="nm-breadcrumb" aria-label="Breadcrumb">
+    <ol class="nm-breadcrumb-list">
+      <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
+      <li class="nm-breadcrumb-sep" aria-hidden="true">/</li>
+      <li class="nm-breadcrumb-item nm-breadcrumb-current" aria-current="page">Transfer Stations</li>
+    </ol>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero hero--has-image">
+    <div class="hero__image" aria-hidden="true">
+      <picture>
+        <img src="/images/heroes/transfers-hero.webp" alt="" loading="eager" />
+      </picture>
+    </div>
+    <div class="hero-inner">
+      <h1 class="hero__title" style="font-family:var(--nm-font);font-size:clamp(2rem,5vw,3rem);font-weight:700;color:var(--nm-text);margin:0 0 var(--nm-space-sm);">Transfer Stations</h1>
+      <p class="hero__subtitle" style="font-family:var(--nm-font);font-size:clamp(1rem,2.5vw,1.25rem);color:var(--nm-text-secondary);margin:0;max-width:640px;">
+        Where to change lines on the DC Metro. Four in-station transfer points and one free walking transfer connect all six Metrorail lines.
+      </p>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <div class="line-page">
+
+    <!-- Transfer Stations List -->
+    <section class="line-stations animate-in d1">
+      <h2 class="line-section-heading">In-Station Transfers</h2>
+      <p style="font-family:var(--nm-font);color:var(--nm-text-secondary);font-size:0.95rem;margin:0 0 var(--nm-space-lg);line-height:1.6;">
+        These stations have platforms for multiple lines, allowing you to transfer without leaving the station or tapping out. Transfers are free and included in your fare.
+      </p>
+
+      <div style="display:flex;flex-direction:column;gap:var(--nm-space-sm);">
+
+        <!-- Metro Center -->
+        <a href="/station/metro-center/" class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);text-decoration:none;color:var(--nm-text);transition:border-color 0.2s,background 0.2s;">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#D41140;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#F09500;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#00A8E8;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#9BA5A5;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h2 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">Metro Center</h2>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Red, Orange, Blue &amp; Silver Lines &middot; Downtown DC</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Platform A (Red) &middot; Platform B (Or/Bl/Sv) &middot; Station codes A01/C01</span>
+          </div>
+          <span class="transfer-station-arrow" style="color:var(--nm-text-muted);flex-shrink:0;"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span>
+        </a>
+
+        <!-- Gallery Place-Chinatown -->
+        <a href="/station/gallery-place/" class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);text-decoration:none;color:var(--nm-text);transition:border-color 0.2s,background 0.2s;">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#D41140;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#00BD45;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#FFD400;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h2 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">Gallery Place-Chinatown</h2>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Red, Green &amp; Yellow Lines &middot; Chinatown / Penn Quarter</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Upper platform (Red) &middot; Lower platform (Gn/Yl) &middot; Station codes B01/F01</span>
+          </div>
+          <span class="transfer-station-arrow" style="color:var(--nm-text-muted);flex-shrink:0;"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span>
+        </a>
+
+        <!-- L'Enfant Plaza -->
+        <a href="/station/lenfant-plaza/" class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);text-decoration:none;color:var(--nm-text);transition:border-color 0.2s,background 0.2s;">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#F09500;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#00A8E8;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#9BA5A5;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#00BD45;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#FFD400;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h2 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">L&#8217;Enfant Plaza</h2>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Orange, Blue, Silver, Green &amp; Yellow Lines &middot; SW Waterfront</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Platform A (Or/Bl/Sv) &middot; Platform B (Gn/Yl) &middot; Station codes D03/F03</span>
+          </div>
+          <span class="transfer-station-arrow" style="color:var(--nm-text-muted);flex-shrink:0;"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span>
+        </a>
+
+        <!-- Fort Totten -->
+        <a href="/" class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);text-decoration:none;color:var(--nm-text);transition:border-color 0.2s,background 0.2s;">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#D41140;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#00BD45;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#FFD400;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h2 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">Fort Totten</h2>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Red, Green &amp; Yellow Lines &middot; NE DC / Maryland border</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Cross-platform transfer (same level) &middot; Station codes B06/E06</span>
+          </div>
+          <span class="transfer-station-arrow" style="color:var(--nm-text-muted);flex-shrink:0;"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span>
+        </a>
+
+      </div>
+    </section>
+
+    <!-- Walking Transfers -->
+    <section class="line-connections animate-in d2">
+      <h2 class="line-section-heading">Walking Transfers</h2>
+      <p style="font-family:var(--nm-font);color:var(--nm-text-secondary);font-size:0.95rem;margin:0 0 var(--nm-space-lg);line-height:1.6;">
+        Free out-of-station transfers between nearby stations. You must tap out at one station and tap in at the other within 30 minutes to avoid being charged a second fare.
+      </p>
+
+      <div style="display:flex;flex-direction:column;gap:var(--nm-space-sm);">
+
+        <!-- Farragut North / Farragut West -->
+        <div class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);color:var(--nm-text);">
+          <div style="flex:1;min-width:0;">
+            <div style="display:flex;align-items:center;gap:var(--nm-space-sm);margin-bottom:var(--nm-space-xs);flex-wrap:wrap;">
+              <span style="font-family:var(--nm-font);font-size:1.05rem;font-weight:600;color:var(--nm-text);">Farragut North</span>
+              <span class="transfer-station-dot" style="background-color:#D41140;width:12px;height:12px;border-radius:50%;display:inline-block;"></span>
+              <span style="font-family:var(--nm-font);font-size:1.1rem;color:var(--nm-text-muted);" aria-label="transfers to">&harr;</span>
+              <span style="font-family:var(--nm-font);font-size:1.05rem;font-weight:600;color:var(--nm-text);">Farragut West</span>
+              <span class="transfer-station-dot" style="background-color:#F09500;width:12px;height:12px;border-radius:50%;display:inline-block;"></span>
+              <span class="transfer-station-dot" style="background-color:#00A8E8;width:12px;height:12px;border-radius:50%;display:inline-block;"></span>
+              <span class="transfer-station-dot" style="background-color:#9BA5A5;width:12px;height:12px;border-radius:50%;display:inline-block;"></span>
+            </div>
+            <p style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Red Line &harr; Orange, Blue &amp; Silver Lines &middot; ~5 minute walk</p>
+            <span style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Tap out and tap in within 30 minutes for free transfer &middot; One block apart on Connecticut Ave &amp; I St NW</span>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- Transfer Tips -->
+    <section class="line-info animate-in d3">
+      <h2 class="line-section-heading">Transfer Tips</h2>
+      <div class="line-info-grid">
+        <div class="line-info-card">
+          <h3 class="line-info-card-title">How Transfers Work</h3>
+          <div class="line-info-rows">
+            <div class="line-info-row">
+              <span class="line-info-label">Cost</span>
+              <span class="line-info-value">Free (included in your fare)</span>
+            </div>
+            <div class="line-info-row">
+              <span class="line-info-label">In-Station</span>
+              <span class="line-info-value">Follow signs to the other platform; no need to tap out</span>
+            </div>
+            <div class="line-info-row">
+              <span class="line-info-label">Walking Transfer</span>
+              <span class="line-info-value">Tap out, walk to the other station, tap in within 30 min</span>
+            </div>
+            <div class="line-info-row">
+              <span class="line-info-label">Transfer Time</span>
+              <span class="line-info-value">2&ndash;5 min in-station, 5&ndash;10 min walking</span>
+            </div>
+          </div>
+        </div>
+        <div class="line-info-card">
+          <h3 class="line-info-card-title">Line Connections</h3>
+          <div class="line-info-rows">
+            <div class="line-info-row">
+              <span class="line-info-label">Red &harr; Or/Bl/Sv</span>
+              <span class="line-info-value">Metro Center or Farragut (walk)</span>
+            </div>
+            <div class="line-info-row">
+              <span class="line-info-label">Red &harr; Gn/Yl</span>
+              <span class="line-info-value">Gallery Place or Fort Totten</span>
+            </div>
+            <div class="line-info-row">
+              <span class="line-info-label">Or/Bl/Sv &harr; Gn/Yl</span>
+              <span class="line-info-value">L&#8217;Enfant Plaza</span>
+            </div>
+            <div class="line-info-row">
+              <span class="line-info-label">Most lines</span>
+              <span class="line-info-value">L&#8217;Enfant Plaza (5 lines, all except Red)</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ Section -->
+    <section class="line-faq">
+      <h2 class="line-section-heading">Frequently Asked Questions</h2>
+      <div class="line-faq-list">
+        <details class="line-faq-item">
+          <summary class="line-faq-question">What are the DC Metro transfer stations?</summary>
+          <div class="line-faq-answer">
+            <p>The DC Metro has four in-system transfer stations where passengers can switch between lines without leaving the station: Metro Center (Red, Orange, Blue, Silver), Gallery Place-Chinatown (Red, Green, Yellow), L&rsquo;Enfant Plaza (Orange, Blue, Silver, Green, Yellow), and Fort Totten (Red, Green, Yellow). There is also a free walking transfer between Farragut North (Red) and Farragut West (Orange, Blue, Silver).</p>
+          </div>
+        </details>
+        <details class="line-faq-item">
+          <summary class="line-faq-question">How do I transfer at Metro Center?</summary>
+          <div class="line-faq-answer">
+            <p>Metro Center has two platforms connected by escalators and elevators. Platform A serves the Red Line (Shady Grove and Glenmont directions), while Platform B serves the Orange, Blue, and Silver Lines. Follow signs for your destination line when transferring. The transfer is free and included in your fare.</p>
+          </div>
+        </details>
+        <details class="line-faq-item">
+          <summary class="line-faq-question">Is there an extra charge to transfer between Metro lines?</summary>
+          <div class="line-faq-answer">
+            <p>No. Transferring between Metrorail lines is free and included in your fare. You do not need to tap out and back in &mdash; simply follow the signs to the other platform within the station. Your fare is calculated based on your origin and final destination, regardless of how many lines you use during your trip.</p>
+          </div>
+        </details>
+        <details class="line-faq-item">
+          <summary class="line-faq-question">Which Metro lines connect at Gallery Place-Chinatown?</summary>
+          <div class="line-faq-answer">
+            <p>Gallery Place-Chinatown connects the Red Line with the Green and Yellow Lines. The upper platform serves the Red Line, while the lower platform serves the Green and Yellow Lines. The station is located in downtown DC near Capital One Arena.</p>
+          </div>
+        </details>
+        <details class="line-faq-item">
+          <summary class="line-faq-question">What is the Farragut walking transfer?</summary>
+          <div class="line-faq-answer">
+            <p>The Farragut walking transfer allows passengers to exit at Farragut North (Red Line) and walk one block to Farragut West (Orange, Blue, Silver Lines), or vice versa, without paying an additional fare. You must tap out at one station and tap in at the other within 30 minutes for the transfer to be free. This is the only free out-of-station transfer in the Metro system.</p>
+          </div>
+        </details>
+        <details class="line-faq-item">
+          <summary class="line-faq-question">How do I get from the Red Line to the Green or Yellow Line?</summary>
+          <div class="line-faq-answer">
+            <p>You can transfer from the Red Line to the Green or Yellow Line at two stations: Gallery Place-Chinatown (downtown DC, near Capital One Arena) or Fort Totten (northeast DC/Maryland border). At Gallery Place, take the escalators between the upper Red Line platform and the lower Green/Yellow platform. At Fort Totten, the transfer is cross-platform on the same level.</p>
+          </div>
+        </details>
+        <details class="line-faq-item">
+          <summary class="line-faq-question">Which station connects the most Metro lines?</summary>
+          <div class="line-faq-answer">
+            <p>L&rsquo;Enfant Plaza connects the most Metro lines &mdash; five of the six lines stop there: Orange, Blue, Silver, Green, and Yellow. The only line that does not serve L&rsquo;Enfant Plaza is the Red Line. It is the busiest transfer station in the system and is located near the National Mall, Smithsonian museums, and several federal agencies.</p>
+          </div>
+        </details>
+        <details class="line-faq-item">
+          <summary class="line-faq-question">How long does it take to transfer between platforms?</summary>
+          <div class="line-faq-answer">
+            <p>In-station transfers typically take 2 to 5 minutes, depending on the station layout and whether you need to use escalators or elevators. At Metro Center and Gallery Place, you&rsquo;ll ride escalators between levels. At Fort Totten, the transfer is cross-platform (same level). The Farragut walking transfer takes about 5 to 10 minutes on foot between the two stations.</p>
+          </div>
+        </details>
+      </div>
+    </section>
+
+    <!-- Disclaimer -->
+    <div class="line-disclaimer">
+      <p>
+        Transfer information is based on the current <a href="https://wmata.com/schedules/maps/upload/system-map-rail.pdf" target="_blank" rel="noopener">WMATA system map</a> and is subject to change during track work or service disruptions. For the most current service information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with WMATA.
+      </p>
+    </div>
+  </div>
+
+  </main>
+
+  <!-- NextMetro Site Footer -->
+  <footer class="nm-footer">
+    <div class="nm-footer__strip" aria-hidden="true">
+      <span></span>
+      <span></span>
+      <span></span>
+      <span></span>
+      <span></span>
+      <span></span>
+    </div>
+    <div class="nm-footer__body">
+      <div class="nm-footer__col">
+        <h2 class="nm-footer__heading">Navigate</h2>
+        <nav class="nm-footer__links" aria-label="Footer navigation">
+          <a href="/"          class="nm-footer__link">Home</a>
+          <a href="https://wmata.com/schedules/maps/upload/system-map-rail.pdf" class="nm-footer__link" target="_blank" rel="noopener noreferrer" title="System Map (PDF, opens in new tab)" aria-label="System Map (PDF, opens in new tab)">System Map</a>
+          <a href="/alerts"    class="nm-footer__link">Alerts</a>
+          <a href="/elevators" class="nm-footer__link">Elevator Status</a>
+          <a href="/fares"     class="nm-footer__link">Fares</a>
+          <a href="/hours"     class="nm-footer__link">Hours</a>
+        </nav>
+      </div>
+      <div class="nm-footer__col">
+        <h2 class="nm-footer__heading">Lines</h2>
+        <nav class="nm-footer__links" aria-label="Metro lines">
+          <a href="/lines/red"    class="nm-footer__link nm-footer__link--line">
+            <span class="nm-footer__dot nm-footer__dot--red"></span>Red Line</a>
+          <a href="/lines/orange" class="nm-footer__link nm-footer__link--line">
+            <span class="nm-footer__dot nm-footer__dot--orange"></span>Orange Line</a>
+          <a href="/lines/silver" class="nm-footer__link nm-footer__link--line">
+            <span class="nm-footer__dot nm-footer__dot--silver"></span>Silver Line</a>
+          <a href="/lines/blue"   class="nm-footer__link nm-footer__link--line">
+            <span class="nm-footer__dot nm-footer__dot--blue"></span>Blue Line</a>
+          <a href="/lines/yellow" class="nm-footer__link nm-footer__link--line">
+            <span class="nm-footer__dot nm-footer__dot--yellow"></span>Yellow Line</a>
+          <a href="/lines/green"  class="nm-footer__link nm-footer__link--line">
+            <span class="nm-footer__dot nm-footer__dot--green"></span>Green Line</a>
+        </nav>
+      </div>
+      <div class="nm-footer__col">
+        <h2 class="nm-footer__heading">About</h2>
+        <nav class="nm-footer__links" aria-label="About">
+          <a href="/about"   class="nm-footer__link">About NextMetro</a>
+          <a href="/privacy" class="nm-footer__link">Privacy Policy</a>
+          <a href="/terms"   class="nm-footer__link">Terms of Service</a>
+          <a href="/crisis"  class="nm-footer__link">Crisis Resources</a>
+          <a href="https://nickpoole.dev" class="nm-footer__link" target="_blank" rel="noopener noreferrer">Webmaster</a>
+        </nav>
+        <div class="nm-footer__data-block">
+          <h2 class="nm-footer__heading">Data</h2>
+          <p class="nm-footer__body-text">
+            Real-time data via WMATA API.<br>
+            Not affiliated with WMATA.
+          </p>
+        </div>
+      </div>
+      <div class="nm-footer__col nm-footer__col--logo">
+        <div class="nm-footer__logo" role="img" aria-label="NextMetro">
+          <div class="nm-footer__logo-mark"><b>NM</b></div>
+          <div class="nm-footer__logo-strip" aria-hidden="true">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+          <div class="nm-footer__logo-text">
+            <span class="nm-footer__logo-next">NEXT</span>
+            <span class="nm-footer__logo-metro">METRO</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="nm-footer__bottom">
+      <span class="nm-footer__copy">&copy; 2026 NextMetro &middot; nextmetro.live</span>
+    </div>
+  </footer>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/transfers/index.html
+++ b/public/transfers/index.html
@@ -448,6 +448,7 @@
           <a href="/elevators" class="nm-footer__link">Elevator Status</a>
           <a href="/fares"     class="nm-footer__link">Fares</a>
           <a href="/hours"     class="nm-footer__link">Hours</a>
+          <a href="/transfers" class="nm-footer__link">Transfers</a>
         </nav>
       </div>
       <div class="nm-footer__col">

--- a/public/transfers/index.html
+++ b/public/transfers/index.html
@@ -178,6 +178,20 @@
     <a href="/hours" class="mobile-menu-link">Hours</a>
   </nav>
 
+  <!-- Station Search -->
+  <div class="station-search" id="station-search-wrapper">
+    <i class="ri-search-line station-search__icon" aria-hidden="true"></i>
+    <input
+      type="text"
+      id="station-input"
+      class="station-search__input"
+      placeholder="Search stations..."
+      autocomplete="off"
+      aria-label="Search for a Metro station"
+    />
+    <ul class="station-dropdown" id="station-dropdown"></ul>
+  </div>
+
   <!-- Transfers Hero -->
   <section class="transfers-hero">
     <div class="transfers-hero-inner">
@@ -302,8 +316,137 @@
       </div>
     </section>
 
+    <!-- Regional Rail Connections -->
+    <section class="line-connections animate-in d3">
+      <h2 class="line-section-heading">Regional Rail Connections</h2>
+      <p style="font-family:var(--nm-font);color:var(--nm-text-secondary);font-size:0.95rem;margin:0 0 var(--nm-space-lg);line-height:1.6;">
+        Several Metro stations connect to Amtrak, MARC, VRE commuter rail, and the DC Streetcar. These connections extend the reach of the Metro system to Baltimore, Virginia&rsquo;s outer suburbs, and beyond.
+      </p>
+
+      <div style="display:flex;flex-direction:column;gap:var(--nm-space-sm);">
+
+        <!-- Union Station -->
+        <a href="/station/union-station/" class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);text-decoration:none;color:var(--nm-text);transition:border-color 0.2s,background 0.2s;">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#D41140;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h3 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">Union Station</h3>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Red Line &middot; Amtrak, MARC (all lines), VRE (both lines)</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Major regional hub &middot; Intercity &amp; commuter rail &middot; Station code B03</span>
+          </div>
+          <span class="transfer-station-arrow" style="color:var(--nm-text-muted);flex-shrink:0;"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span>
+        </a>
+
+        <!-- L'Enfant Plaza (VRE) -->
+        <a href="/station/lenfant-plaza/" class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);text-decoration:none;color:var(--nm-text);transition:border-color 0.2s,background 0.2s;">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#F09500;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#00A8E8;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#9BA5A5;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#00BD45;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#FFD400;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h3 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">L&#8217;Enfant Plaza</h3>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Orange, Blue, Silver, Green &amp; Yellow Lines &middot; VRE (both lines)</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Adjacent VRE station &middot; Short walk via 2nd St SW &middot; Station codes D03/F03</span>
+          </div>
+          <span class="transfer-station-arrow" style="color:var(--nm-text-muted);flex-shrink:0;"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span>
+        </a>
+
+        <!-- King Street-Old Town -->
+        <div class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);color:var(--nm-text);">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#00A8E8;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#FFD400;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h3 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">King Street-Old Town</h3>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Blue &amp; Yellow Lines &middot; VRE (both lines), Amtrak</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Shared platform with VRE/Amtrak &middot; Alexandria, VA &middot; Station code C13</span>
+          </div>
+        </div>
+
+        <!-- Franconia-Springfield -->
+        <div class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);color:var(--nm-text);">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#00A8E8;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h3 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">Franconia-Springfield</h3>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Blue Line &middot; VRE (Fredericksburg line)</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Adjacent VRE station &middot; Springfield, VA &middot; Station code J03</span>
+          </div>
+        </div>
+
+        <!-- New Carrollton -->
+        <div class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);color:var(--nm-text);">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#F09500;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h3 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">New Carrollton</h3>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Orange Line &middot; Amtrak, MARC (Penn line)</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Adjacent Amtrak/MARC station &middot; Lanham, MD &middot; Station code D13</span>
+          </div>
+        </div>
+
+        <!-- Silver Spring -->
+        <div class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);color:var(--nm-text);">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#D41140;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h3 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">Silver Spring</h3>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Red Line &middot; MARC (Brunswick line)</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Adjacent MARC station &middot; Silver Spring, MD &middot; Station code B08</span>
+          </div>
+        </div>
+
+        <!-- College Park -->
+        <div class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);color:var(--nm-text);">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#00BD45;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#FFD400;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h3 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">College Park-U of Md</h3>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Green &amp; Yellow Lines &middot; MARC (Camden line)</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Adjacent MARC station &middot; College Park, MD &middot; Station code E09</span>
+          </div>
+        </div>
+
+        <!-- Greenbelt -->
+        <div class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);color:var(--nm-text);">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#00BD45;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h3 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">Greenbelt</h3>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Green Line &middot; MARC (Camden line)</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Adjacent MARC station &middot; Greenbelt, MD &middot; Station code E10</span>
+          </div>
+        </div>
+
+        <!-- H Street/Benning Road (DC Streetcar) -->
+        <div class="transfer-station-card" style="display:flex;align-items:center;gap:var(--nm-space-md);padding:var(--nm-space-md) var(--nm-space-lg);background:var(--nm-surface);border:1px solid var(--nm-border-subtle);border-radius:var(--nm-radius-md);color:var(--nm-text);">
+          <div class="transfer-station-lines" style="display:flex;gap:6px;flex-shrink:0;">
+            <span class="transfer-station-dot" style="background-color:#00A8E8;width:14px;height:14px;border-radius:50%;display:block;"></span>
+            <span class="transfer-station-dot" style="background-color:#9BA5A5;width:14px;height:14px;border-radius:50%;display:block;"></span>
+          </div>
+          <div class="transfer-station-info" style="flex:1;min-width:0;">
+            <h3 class="transfer-station-name" style="font-family:var(--nm-font);font-size:1.15rem;font-weight:600;margin:0 0 2px;color:var(--nm-text);">Benning Road</h3>
+            <p class="transfer-station-desc" style="font-family:var(--nm-font);font-size:0.85rem;color:var(--nm-text-secondary);margin:0 0 2px;">Blue &amp; Silver Lines &middot; DC Streetcar (H Street line)</p>
+            <span class="transfer-station-detail" style="font-family:var(--nm-font);font-size:0.78rem;color:var(--nm-text-muted);">Streetcar stops at station entrance &middot; NE DC &middot; Station code G01</span>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
     <!-- Transfer Tips -->
-    <section class="line-info animate-in d3">
+    <section class="line-info animate-in d4">
       <h2 class="line-section-heading">Transfer Tips</h2>
       <div class="line-info-grid">
         <div class="line-info-card">
@@ -352,7 +495,7 @@
     </section>
 
     <!-- FAQ Section -->
-    <section class="line-faq">
+    <section class="line-faq animate-in d5">
       <h2 class="line-section-heading">Frequently Asked Questions</h2>
       <div class="line-faq-list">
         <details class="line-faq-item">
@@ -496,5 +639,6 @@
     </div>
   </footer>
   <script src="/js/nav.js"></script>
+  <script src="/js/search.js"></script>
 </body>
 </html>

--- a/public/transfers/index.html
+++ b/public/transfers/index.html
@@ -182,8 +182,16 @@
     <div class="ticker-track"></div>
   </div>
 
+  <!-- Transfers Hero -->
+  <section class="transfers-hero">
+    <div class="transfers-hero-inner">
+      <span class="transfers-hero-label">Connections</span>
+      <h1 class="transfers-hero-title">Transfer Stations</h1>
+      <p class="transfers-hero-subtitle">Where to change lines on the DC Metro. Four in-station transfer points and one free walking transfer connect all six Metrorail lines.</p>
+    </div>
+  </section>
+
   <main id="main-content">
-  <!-- Breadcrumb -->
   <nav class="nm-breadcrumb" aria-label="Breadcrumb">
     <ol class="nm-breadcrumb-list">
       <li class="nm-breadcrumb-item"><a href="/">Home</a></li>
@@ -192,22 +200,6 @@
     </ol>
   </nav>
 
-  <!-- Hero -->
-  <section class="hero hero--has-image">
-    <div class="hero__image" aria-hidden="true">
-      <picture>
-        <img src="/images/heroes/transfers-hero.webp" alt="" loading="eager" />
-      </picture>
-    </div>
-    <div class="hero-inner">
-      <h1 class="hero__title" style="font-family:var(--nm-font);font-size:clamp(2rem,5vw,3rem);font-weight:700;color:var(--nm-text);margin:0 0 var(--nm-space-sm);">Transfer Stations</h1>
-      <p class="hero__subtitle" style="font-family:var(--nm-font);font-size:clamp(1rem,2.5vw,1.25rem);color:var(--nm-text-secondary);margin:0;max-width:640px;">
-        Where to change lines on the DC Metro. Four in-station transfer points and one free walking transfer connect all six Metrorail lines.
-      </p>
-    </div>
-  </section>
-
-  <!-- Main Content -->
   <div class="line-page">
 
     <!-- Transfer Stations List -->


### PR DESCRIPTION
## Summary
This PR adds a comprehensive Transfer Stations guide page and implements a unified breadcrumb navigation component across the site. The changes improve navigation consistency and provide users with detailed information about DC Metro transfer points.

## Key Changes

### New Pages & Content
- **Transfer Stations Page** (`/transfers/`): New comprehensive guide featuring:
  - Four in-station transfer stations (Metro Center, Gallery Place-Chinatown, L'Enfant Plaza, Fort Totten)
  - Free walking transfer information (Farragut North/West)
  - Detailed platform information, station codes, and transfer instructions
  - FAQ schema markup with 8 common questions about transfers
  - Breadcrumb and Open Graph metadata for SEO

### Navigation Improvements
- **Unified Breadcrumb Component**: Replaced line-specific breadcrumbs with a consistent `.nm-breadcrumb` component
  - Applied across all pages: line pages (Red, Blue, Green, Orange, Silver, Yellow), station pages, alerts, elevators, and utility pages (About, Crisis, Fares, Hours)
  - Styled with underlined links, large tap targets (44px min-height), and amber hover states
  - Responsive design with adjusted padding on mobile

### Styling & Layout
- Added `transfers.css` with card-based layouts for transfer stations and walking transfers
- Enhanced `line.css` with hero image support (background images with opacity and blend modes)
- Updated `styles.css` with breadcrumb styling and responsive behavior
- Added background images to hero sections (fares page, alerts page)

### Alerts Page Enhancements
- Added line filter chips to filter alerts by specific Metro lines
- Integrated `line.css` stylesheet for consistent styling
- Added filter state management in `alerts.js` with `activeLineFilter` variable and `getFilteredAlerts()` function

### Station Pages Updated
- Added breadcrumb navigation to all station pages with appropriate parent links:
  - Transfer stations link to `/transfers/`
  - Line-specific stations link to their respective line pages

## Implementation Details
- Breadcrumb uses semantic HTML (`<nav>`, `<ol>`, `<li>`) with proper ARIA attributes
- Transfer station cards use inline styles for flexibility while maintaining design consistency
- Schema markup includes BreadcrumbList and FAQPage structured data for improved SEO
- Filter functionality in alerts uses data attributes (`data-line`) for line identification
- All new components follow existing design token patterns (CSS custom properties)

https://claude.ai/code/session_01DUoi9kJSDznkKy1SBJzkE6