### PR TITLE
Add WMATA API data disclaimer across all pages

### DIFF
--- a/public/alerts/index.html
+++ b/public/alerts/index.html
@@ -374,6 +374,13 @@
   </section>
 
     </div>
+
+    <div class="wmata-data-disclaimer" style="max-width:900px;margin:var(--nm-space-lg) auto;">
+      <p>
+        <strong>WMATA Transit information provided on this site is subject to change without notice.</strong>
+        Alert data is sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and updates every 30 seconds. NextMetro is not affiliated with, endorsed by, or connected to WMATA.
+      </p>
+    </div>
   </main>
 
   <!-- NextMetro Site Footer -->

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -493,3 +493,25 @@ a:hover {
     padding: var(--nm-space-sm) var(--nm-space-md);
   }
 }
+
+/* ==============================
+   WMATA Data Disclaimer
+   Required by WMATA API Developer Agreement.
+   Must appear in legible bold print on the same
+   page as transit data, in close proximity.
+   ============================== */
+.wmata-data-disclaimer {
+  margin: var(--nm-space-md) 0;
+  padding: var(--nm-space-sm) var(--nm-space-md);
+  border: 1px solid var(--nm-border);
+  background: var(--nm-surface);
+  font-family: var(--nm-font);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--nm-text-secondary);
+}
+
+.wmata-data-disclaimer strong {
+  color: var(--nm-text-primary);
+  font-weight: 700;
+}

--- a/public/elevators/index.html
+++ b/public/elevators/index.html
@@ -353,6 +353,13 @@
   </section>
 
     </div>
+
+    <div class="wmata-data-disclaimer" style="max-width:900px;margin:var(--nm-space-lg) auto;">
+      <p>
+        <strong>WMATA Transit information provided on this site is subject to change without notice.</strong>
+        Elevator and escalator data is sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and updates every 30 seconds. NextMetro is not affiliated with, endorsed by, or connected to WMATA.
+      </p>
+    </div>
   </main>
 
   <!-- NextMetro Site Footer -->

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -388,7 +388,8 @@
     <!-- Disclaimer -->
     <div class="fares-disclaimer">
       <p>
-        Fares shown are sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and may not reflect temporary promotions or fare changes. For the most current fare information, visit <a href="https://www.wmata.com/fares/" target="_blank" rel="noopener">wmata.com/fares</a>. NextMetro is not affiliated with WMATA.
+        <strong>WMATA Transit information provided on this site is subject to change without notice.</strong>
+        Fares shown are sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and may not reflect temporary promotions or fare changes. For the most current fare information, visit <a href="https://www.wmata.com/fares/" target="_blank" rel="noopener">wmata.com/fares</a>. NextMetro is not affiliated with, endorsed by, or connected to WMATA.
       </p>
     </div>
   </div>

--- a/public/hours/index.html
+++ b/public/hours/index.html
@@ -919,7 +919,8 @@
     <!-- Disclaimer -->
     <div class="hours-disclaimer">
       <p>
-        Schedule information is based on published WMATA data as of March 2026. Metro schedules change periodically — typically in June and December each year. For the most current information, visit <a href="https://www.wmata.com" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with WMATA. This is an independent project using publicly available data.
+        <strong>WMATA Transit information provided on this site is subject to change without notice.</strong>
+        Schedule information is based on published WMATA data as of March 2026. Metro schedules change periodically — typically in June and December each year. For the most current information, visit <a href="https://www.wmata.com" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with, endorsed by, or connected to WMATA.
       </p>
     </div>
   </div>

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <title>NextMetro — Real-Time DC Metro Arrivals</title>
-  <meta name="description" content="Live arrival times for all 98 Washington DC Metro stations. Track trains on the Red, Orange, Blue, Yellow, Green, and Silver lines. Fast, accurate, free." />
+  <meta name="description" content="Live arrival times for all 98 Washington DC Metro stations. Track trains on the Red, Orange, Blue, Yellow, Green, and Silver lines. Fast and free." />
 
   <!-- Open Graph -->
   <meta property="og:title" content="NextMetro — Real-Time DC Metro Arrivals" />
@@ -301,7 +301,7 @@
       <p>
         NextMetro provides real-time arrival information for the Washington DC Metro system.
         Track trains across all 98 stations on the Red, Orange, Blue, Yellow, Green, and Silver lines.
-        Fast, accurate, and built for daily commuters.
+        Fast, free, and built for daily commuters.
       </p>
     </section>
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -747,6 +747,27 @@ function updateTimestamp() {
 }
 
 // ==============================
+// WMATA Data Disclaimer (required by API agreement)
+// ==============================
+function injectWmataDisclaimer() {
+  // Avoid duplicate injection
+  if (document.querySelector('.wmata-data-disclaimer')) return;
+
+  var disclaimer = document.createElement('div');
+  disclaimer.className = 'wmata-data-disclaimer';
+  disclaimer.innerHTML =
+    '<strong>WMATA Transit information provided on this site is subject to change without notice.</strong> ' +
+    'NextMetro is not affiliated with, endorsed by, or connected to WMATA. ' +
+    'Arrival times are estimates and may not reflect actual conditions.';
+
+  // Insert after last-updated element (right below PIDS boards)
+  var anchor = lastUpdatedEl;
+  if (anchor && anchor.parentNode) {
+    anchor.parentNode.insertBefore(disclaimer, anchor.nextSibling);
+  }
+}
+
+// ==============================
 // Fetch Train Predictions (with directional grouping)
 // ==============================
 async function fetchTrains(stationCode) {
@@ -985,6 +1006,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Update system status time
   updateSystemStatusTime();
   setInterval(updateSystemStatusTime, 60000);
+
+  // Inject WMATA data disclaimer near PIDS boards
+  injectWmataDisclaimer();
 
   // Render system status immediately (all lines Normal) before API returns
   renderSystemStatus([]);

--- a/public/lines/blue/index.html
+++ b/public/lines/blue/index.html
@@ -6,7 +6,7 @@
 		<title>Blue Line — Stations, Status & Alerts | NextMetro</title>
 		<meta
 			name="description"
-			content="Blue Line status, service alerts, and all 27 stations from Franconia-Springfield to Downtown Largo. Live updates, transfer info, and service hours for the DC Metro Blue Line serving Reagan National Airport, Alexandria, Pentagon, and downtown D.C." />
+			content="Blue Line status, service alerts, and all 28 stations from Franconia-Springfield to Downtown Largo. Live updates, transfer info, and service hours for the DC Metro Blue Line serving Reagan National Airport, Alexandria, Pentagon, and downtown D.C." />
 		<link rel="canonical" href="https://nextmetro.live/lines/blue/" />
 
 		<!-- Favicon -->
@@ -33,7 +33,7 @@
 		<meta property="og:title" content="Blue Line — Stations, Status & Alerts | NextMetro" />
 		<meta
 			property="og:description"
-			content="Blue Line status, service alerts, and all 27 stations from Franconia-Springfield to Downtown Largo. Live updates for the DC Metro Blue Line." />
+			content="Blue Line status, service alerts, and all 28 stations from Franconia-Springfield to Downtown Largo. Live updates for the DC Metro Blue Line." />
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://nextmetro.live/lines/blue/" />
 		<meta property="og:site_name" content="NextMetro" />
@@ -43,14 +43,14 @@
 		<meta property="og:image:height" content="630" />
 		<meta
 			property="og:image:alt"
-			content="DC Metro Blue Line — 27 stations from Franconia-Springfield to Downtown Largo" />
+			content="DC Metro Blue Line — 28 stations from Franconia-Springfield to Downtown Largo" />
 
 		<!-- Twitter Card -->
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="Blue Line — Stations, Status & Alerts | NextMetro" />
 		<meta
 			name="twitter:description"
-			content="Blue Line status, service alerts, and all 27 stations from Franconia-Springfield to Downtown Largo. Live updates for the DC Metro Blue Line." />
+			content="Blue Line status, service alerts, and all 28 stations from Franconia-Springfield to Downtown Largo. Live updates for the DC Metro Blue Line." />
 		<meta name="twitter:image" content="https://nextmetro.live/images/og/lines/og-blue-line.png" />
 
 		<!-- Schema: TransitLine + BreadcrumbList + FAQPage + OpeningHoursSpecification -->
@@ -61,7 +61,7 @@
 					"@type": "GovernmentService",
 					"name": "Blue Line",
 					"alternateName": "Metrorail Blue Line",
-					"description": "The Blue Line runs 30.8 miles with 27 stations from Franconia-Springfield in Virginia through Alexandria, the Pentagon, downtown Washington, D.C., and into Prince George's County, Maryland to Downtown Largo. Along with the Yellow Line, it directly serves Reagan National Airport.",
+					"description": "The Blue Line runs 30.8 miles with 28 stations from Franconia-Springfield in Virginia through Alexandria, the Pentagon, downtown Washington, D.C., and into Prince George's County, Maryland to Downtown Largo. Along with the Yellow Line, it directly serves Reagan National Airport.",
 					"serviceType": "Public Transit — Metrorail",
 					"provider": {
 						"@type": "GovernmentOrganization",
@@ -129,7 +129,7 @@
 							"name": "How many stations does the DC Metro Blue Line have?",
 							"acceptedAnswer": {
 								"@type": "Answer",
-								"text": "The DC Metro Blue Line has 27 stations, running from Franconia-Springfield in Fairfax County, Virginia through Alexandria, the Pentagon, downtown Washington, D.C., and into Prince George's County, Maryland to Downtown Largo. The line spans 30.8 miles."
+								"text": "The DC Metro Blue Line has 28 stations, running from Franconia-Springfield in Fairfax County, Virginia through Alexandria, the Pentagon, downtown Washington, D.C., and into Prince George's County, Maryland to Downtown Largo. The line spans 30.8 miles."
 							}
 						},
 						{
@@ -185,7 +185,7 @@
 							"name": "How long does it take to ride the entire Blue Line?",
 							"acceptedAnswer": {
 								"@type": "Answer",
-								"text": "A complete end-to-end ride from Franconia-Springfield to Downtown Largo takes approximately 52 minutes. The Blue Line covers 30.8 miles and passes through 27 stations across Virginia, the District of Columbia, and Maryland. The first segment of the Blue Line opened in 1977."
+								"text": "A complete end-to-end ride from Franconia-Springfield to Downtown Largo takes approximately 52 minutes. The Blue Line covers 30.8 miles and passes through 28 stations across Virginia, the District of Columbia, and Maryland. The first segment of the Blue Line opened in 1977."
 							}
 						},
 						{
@@ -294,7 +294,7 @@
 				<div class="line-hero-bar"></div>
 				<h1 class="line-hero-title">Blue Line</h1>
 				<p class="line-hero-subtitle">
-					27 stations
+					28 stations
 					<span class="line-hero-separator">&middot;</span>
 					Franconia-Springfield to Downtown Largo
 				</p>
@@ -339,7 +339,7 @@
 						</span>
 						<span class="line-termini-track">
 							<span class="line-termini-line"></span>
-							<span class="line-termini-count">27 stations &middot; 30.8 mi</span>
+							<span class="line-termini-count">28 stations &middot; 30.8 mi</span>
 						</span>
 						<span class="line-termini-station">
 							Downtown Largo
@@ -429,6 +429,19 @@
 							<span class="line-station-info">
 								<span class="line-station-name">Braddock Road</span>
 								<span class="station-ground-level">Ground Level</span>
+							</span>
+							<span class="line-station-arrow">
+								<i class="ri-arrow-right-s-line" aria-hidden="true"></i>
+							</span>
+						</a>
+						<a href="/station/potomac-yard/" class="line-station-row line-station-row--outdoor" data-code="C11">
+							<span class="line-station-dot-col">
+								<span class="line-station-dot"></span>
+								<span class="line-station-connector"></span>
+							</span>
+							<span class="line-station-info">
+								<span class="line-station-name">Potomac Yard</span>
+								<span class="station-elevated">Elevated</span>
 							</span>
 							<span class="line-station-arrow">
 								<i class="ri-arrow-right-s-line" aria-hidden="true"></i>
@@ -793,7 +806,7 @@
 								</div>
 								<div class="line-info-row">
 									<span class="line-info-label">Stations</span>
-									<span class="line-info-value">27</span>
+									<span class="line-info-value">28</span>
 								</div>
 								<div class="line-info-row">
 									<span class="line-info-label">Transfer Stations</span>
@@ -913,7 +926,7 @@
 							</summary>
 							<div class="line-faq-answer">
 								<p>
-									The DC Metro Blue Line has 27 stations, running from Franconia-Springfield in
+									The DC Metro Blue Line has 28 stations, running from Franconia-Springfield in
 									Fairfax County, Virginia through Alexandria, the Pentagon, downtown Washington,
 									D.C., and into Prince George's County, Maryland to Downtown Largo. The line spans
 									30.8 miles.
@@ -996,7 +1009,7 @@
 							<div class="line-faq-answer">
 								<p>
 									A complete end-to-end ride from Franconia-Springfield to Downtown Largo takes
-									approximately 52 minutes. The Blue Line covers 30.8 miles and passes through 27
+									approximately 52 minutes. The Blue Line covers 30.8 miles and passes through 28
 									stations across Virginia, the District of Columbia, and Maryland. The first segment
 									of the Blue Line opened in 1977.
 								</p>

--- a/public/lines/blue/index.html
+++ b/public/lines/blue/index.html
@@ -1030,12 +1030,13 @@
 				<!-- Disclaimer -->
 				<div class="line-disclaimer">
 					<p>
+						<strong>WMATA Transit information provided on this site is subject to change without notice.</strong>
 						Status and alerts are sourced from the
 						<a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a>
 						and update every 60 seconds. Service hours are effective June 22, 2025 and subject to change for
 						holidays and special events. For the most current information, visit
 						<a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>
-						. NextMetro is not affiliated with WMATA.
+						. NextMetro is not affiliated with, endorsed by, or connected to WMATA.
 					</p>
 				</div>
 			</div>

--- a/public/lines/green/index.html
+++ b/public/lines/green/index.html
@@ -515,7 +515,8 @@
     <!-- Disclaimer -->
     <div class="line-disclaimer">
       <p>
-        Status and alerts are sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and update every 60 seconds. Service hours are effective June 22, 2025 and subject to change for holidays and special events. For the most current information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with WMATA.
+        <strong>WMATA Transit information provided on this site is subject to change without notice.</strong>
+        Status and alerts are sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and update every 60 seconds. Service hours are effective June 22, 2025 and subject to change for holidays and special events. For the most current information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with, endorsed by, or connected to WMATA.
       </p>
     </div>
   </div>

--- a/public/lines/orange/index.html
+++ b/public/lines/orange/index.html
@@ -520,7 +520,8 @@
     <!-- Disclaimer -->
     <div class="line-disclaimer">
       <p>
-        Status and alerts are sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and update every 60 seconds. Service hours are effective June 22, 2025 and subject to change for holidays and special events. For the most current information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with WMATA.
+        <strong>WMATA Transit information provided on this site is subject to change without notice.</strong>
+        Status and alerts are sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and update every 60 seconds. Service hours are effective June 22, 2025 and subject to change for holidays and special events. For the most current information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with, endorsed by, or connected to WMATA.
       </p>
     </div>
   </div>

--- a/public/lines/red/index.html
+++ b/public/lines/red/index.html
@@ -521,7 +521,8 @@
     <!-- Disclaimer -->
     <div class="line-disclaimer">
       <p>
-        Status and alerts are sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and update every 60 seconds. Service hours are effective June 22, 2025 and subject to change for holidays and special events. For the most current information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with WMATA.
+        <strong>WMATA Transit information provided on this site is subject to change without notice.</strong>
+        Status and alerts are sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and update every 60 seconds. Service hours are effective June 22, 2025 and subject to change for holidays and special events. For the most current information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with, endorsed by, or connected to WMATA.
       </p>
     </div>
   </div>

--- a/public/lines/silver/index.html
+++ b/public/lines/silver/index.html
@@ -528,7 +528,8 @@
     <!-- Disclaimer -->
     <div class="line-disclaimer">
       <p>
-        Status and alerts are sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and update every 60 seconds. Service hours are effective June 22, 2025 and subject to change for holidays and special events. For the most current information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with WMATA.
+        <strong>WMATA Transit information provided on this site is subject to change without notice.</strong>
+        Status and alerts are sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and update every 60 seconds. Service hours are effective June 22, 2025 and subject to change for holidays and special events. For the most current information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with, endorsed by, or connected to WMATA.
       </p>
     </div>
   </div>

--- a/public/lines/yellow/index.html
+++ b/public/lines/yellow/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Yellow Line — Stations, Status & Alerts | NextMetro</title>
-  <meta name="description" content="Yellow Line status, service alerts, and all 21 stations from Huntington to Greenbelt. Live updates, transfer info, and service hours for the DC Metro Yellow Line." />
+  <meta name="description" content="Yellow Line status, service alerts, and all 22 stations from Huntington to Greenbelt. Live updates, transfer info, and service hours for the DC Metro Yellow Line." />
   <link rel="canonical" href="https://nextmetro.live/lines/yellow/" />
 
   <!-- Favicon -->
@@ -27,7 +27,7 @@
 
   <!-- Open Graph -->
   <meta property="og:title" content="Yellow Line — Stations, Status & Alerts | NextMetro" />
-  <meta property="og:description" content="Yellow Line status, service alerts, and all 21 stations from Huntington to Greenbelt. Live updates for the DC Metro Yellow Line." />
+  <meta property="og:description" content="Yellow Line status, service alerts, and all 22 stations from Huntington to Greenbelt. Live updates for the DC Metro Yellow Line." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://nextmetro.live/lines/yellow/" />
   <meta property="og:site_name" content="NextMetro" />
@@ -35,12 +35,12 @@
   <meta property="og:image" content="https://nextmetro.live/images/og/lines/og-yellow-line.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
-  <meta property="og:image:alt" content="DC Metro Yellow Line — 21 stations from Huntington to Greenbelt" />
+  <meta property="og:image:alt" content="DC Metro Yellow Line — 22 stations from Huntington to Greenbelt" />
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Yellow Line — Stations, Status & Alerts | NextMetro" />
-  <meta name="twitter:description" content="Yellow Line status, service alerts, and all 21 stations from Huntington to Greenbelt. Live updates for the DC Metro Yellow Line." />
+  <meta name="twitter:description" content="Yellow Line status, service alerts, and all 22 stations from Huntington to Greenbelt. Live updates for the DC Metro Yellow Line." />
   <meta name="twitter:image" content="https://nextmetro.live/images/og/lines/og-yellow-line.png" />
 
   <!-- Schema: TransitLine + BreadcrumbList + FAQPage + OpeningHoursSpecification -->
@@ -51,7 +51,7 @@
       "@type": "GovernmentService",
       "name": "Yellow Line",
       "alternateName": "Metrorail Yellow Line",
-      "description": "The Yellow Line connects Huntington in Fairfax County, Virginia to Greenbelt in Prince George's County, Maryland, running 24.0 miles with 21 stations through Alexandria, the Pentagon, and downtown Washington, D.C. It shares tracks with the Green Line between L'Enfant Plaza and Greenbelt.",
+      "description": "The Yellow Line connects Huntington in Fairfax County, Virginia to Greenbelt in Prince George's County, Maryland, running 24.0 miles with 22 stations through Alexandria, the Pentagon, and downtown Washington, D.C. It shares tracks with the Green Line between L'Enfant Plaza and Greenbelt.",
       "serviceType": "Public Transit — Metrorail",
       "provider": {
         "@type": "GovernmentOrganization",
@@ -119,7 +119,7 @@
           "name": "How many stations does the DC Metro Yellow Line have?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "The DC Metro Yellow Line has 21 stations, running from Huntington in Fairfax County, Virginia through downtown Washington, D.C. to Greenbelt in Prince George's County, Maryland. The line is 24.0 miles long."
+            "text": "The DC Metro Yellow Line has 22 stations, running from Huntington in Fairfax County, Virginia through downtown Washington, D.C. to Greenbelt in Prince George's County, Maryland. The line is 24.0 miles long."
           }
         },
         {
@@ -175,7 +175,7 @@
           "name": "How long does it take to ride the entire Yellow Line?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "A complete end-to-end ride from Huntington to Greenbelt takes approximately 44 minutes. The Yellow Line covers 24.0 miles and passes through 21 stations across Fairfax County, Virginia, Alexandria, Washington, D.C., and Prince George's County, Maryland."
+            "text": "A complete end-to-end ride from Huntington to Greenbelt takes approximately 44 minutes. The Yellow Line covers 24.0 miles and passes through 22 stations across Fairfax County, Virginia, Alexandria, Washington, D.C., and Prince George's County, Maryland."
           }
         },
         {
@@ -260,7 +260,7 @@
       <span class="line-hero-label"><span class="line-hero-label-dot"></span>Line</span>
       <div class="line-hero-bar"></div>
       <h1 class="line-hero-title">Yellow Line</h1>
-      <p class="line-hero-subtitle">21 stations<span class="line-hero-separator">&middot;</span>Huntington to Greenbelt</p>
+      <p class="line-hero-subtitle">22 stations<span class="line-hero-separator">&middot;</span>Huntington to Greenbelt</p>
 
       <!-- Status Hero -->
       <div class="line-status" id="line-status">
@@ -303,7 +303,7 @@
         </span>
         <span class="line-termini-track">
           <span class="line-termini-line"></span>
-          <span class="line-termini-count">21 stations &middot; 24.0 mi</span>
+          <span class="line-termini-count">22 stations &middot; 24.0 mi</span>
         </span>
         <span class="line-termini-station">
           Greenbelt
@@ -320,6 +320,7 @@
         <a href="/" class="line-station-row line-station-row--outdoor" data-code="C14"><span class="line-station-dot-col"><span class="line-station-dot"></span><span class="line-station-connector"></span></span><span class="line-station-info"><span class="line-station-name">Eisenhower Ave</span><span class="line-station-badges"><span class="station-badge station-badge--parking" title="Parking available"><i class="ri-parking-box-line" aria-hidden="true"></i></span></span><span class="station-elevated">Elevated</span></span><span class="line-station-arrow"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span></a>
         <a href="/" class="line-station-row line-station-row--outdoor" data-code="C13"><span class="line-station-dot-col"><span class="line-station-dot line-station-dot--transfer"></span><span class="line-station-connector"></span></span><span class="line-station-info"><span class="line-station-name">King Street-Old Town</span><span class="line-station-badges"><span class="station-transfer"><span class="station-transfer-dot station-transfer-dot--blue" title="Blue Line"></span><span class="station-transfer-label">Transfer</span></span><span class="station-badge station-badge--parking" title="Parking available"><i class="ri-parking-box-line" aria-hidden="true"></i></span><span class="station-badge station-badge--external" title="Amtrak"><i class="ri-train-line" aria-hidden="true"></i>Amtrak</span><span class="station-badge station-badge--external" title="VRE"><i class="ri-train-line" aria-hidden="true"></i>VRE</span></span><span class="station-elevated">Elevated</span></span><span class="line-station-arrow"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span></a>
         <a href="/" class="line-station-row line-station-row--outdoor" data-code="C12"><span class="line-station-dot-col"><span class="line-station-dot"></span><span class="line-station-connector"></span></span><span class="line-station-info"><span class="line-station-name">Braddock Road</span><span class="station-ground-level">Ground Level</span></span><span class="line-station-arrow"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span></a>
+        <a href="/station/potomac-yard/" class="line-station-row line-station-row--outdoor" data-code="C11"><span class="line-station-dot-col"><span class="line-station-dot"></span><span class="line-station-connector"></span></span><span class="line-station-info"><span class="line-station-name">Potomac Yard</span><span class="station-elevated">Elevated</span></span><span class="line-station-arrow"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span></a>
         <a href="/station/reagan-airport/" class="line-station-row line-station-row--outdoor" data-code="C10"><span class="line-station-dot-col"><span class="line-station-dot"></span><span class="line-station-connector"></span></span><span class="line-station-info"><span class="line-station-name">Ronald Reagan Washington National Airport</span><span class="station-elevated">Elevated</span></span><span class="line-station-arrow"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span></a>
         <a href="/" class="line-station-row" data-code="C09"><span class="line-station-dot-col"><span class="line-station-dot"></span><span class="line-station-connector"></span></span><span class="line-station-info"><span class="line-station-name">Crystal City</span></span><span class="line-station-arrow"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span></a>
         <a href="/" class="line-station-row" data-code="C08"><span class="line-station-dot-col"><span class="line-station-dot"></span><span class="line-station-connector"></span></span><span class="line-station-info"><span class="line-station-name">Pentagon City</span></span><span class="line-station-arrow"><i class="ri-arrow-right-s-line" aria-hidden="true"></i></span></a>
@@ -452,7 +453,7 @@
         <details class="line-faq-item">
           <summary class="line-faq-question">How many stations does the DC Metro Yellow Line have?</summary>
           <div class="line-faq-answer">
-            <p>The DC Metro Yellow Line has 21 stations, running from Huntington in Fairfax County, Virginia through downtown Washington, D.C. to Greenbelt in Prince George's County, Maryland. The line is 24.0 miles long.</p>
+            <p>The DC Metro Yellow Line has 22 stations, running from Huntington in Fairfax County, Virginia through downtown Washington, D.C. to Greenbelt in Prince George's County, Maryland. The line is 24.0 miles long.</p>
           </div>
         </details>
         <details class="line-faq-item">
@@ -494,7 +495,7 @@
         <details class="line-faq-item">
           <summary class="line-faq-question">How long does it take to ride the entire Yellow Line?</summary>
           <div class="line-faq-answer">
-            <p>A complete end-to-end ride from Huntington to Greenbelt takes approximately 44 minutes. The Yellow Line covers 24.0 miles and passes through 21 stations across Fairfax County, Virginia, Alexandria, Washington, D.C., and Prince George&rsquo;s County, Maryland.</p>
+            <p>A complete end-to-end ride from Huntington to Greenbelt takes approximately 44 minutes. The Yellow Line covers 24.0 miles and passes through 22 stations across Fairfax County, Virginia, Alexandria, Washington, D.C., and Prince George&rsquo;s County, Maryland.</p>
           </div>
         </details>
         <details class="line-faq-item">

--- a/public/lines/yellow/index.html
+++ b/public/lines/yellow/index.html
@@ -515,7 +515,8 @@
     <!-- Disclaimer -->
     <div class="line-disclaimer">
       <p>
-        Status and alerts are sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and update every 60 seconds. Service hours are effective June 22, 2025 and subject to change for holidays and special events. For the most current information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with WMATA.
+        <strong>WMATA Transit information provided on this site is subject to change without notice.</strong>
+        Status and alerts are sourced from the <a href="https://developer.wmata.com/" target="_blank" rel="noopener">WMATA API</a> and update every 60 seconds. Service hours are effective June 22, 2025 and subject to change for holidays and special events. For the most current information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with, endorsed by, or connected to WMATA.
       </p>
     </div>
   </div>

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -97,7 +97,7 @@
   <div class="legal-page">
     <span class="legal-label">Legal</span>
     <h1 class="legal-title">Privacy Policy</h1>
-    <p class="legal-meta">Effective Date: March 10, 2026 &middot; Last Updated: March 10, 2026</p>
+    <p class="legal-meta">Effective Date: March 10, 2026 &middot; Last Updated: March 17, 2026</p>
 
     <div class="legal-callout">
       <h2 class="legal-callout-heading">The Short Version</h2>
@@ -582,7 +582,7 @@
     </div>
 
     <div class="legal-footer-note">
-      <p>Last Updated: March 10, 2026</p>
+      <p>Last Updated: March 17, 2026</p>
       <p>&copy; 2026 NextMetro. All rights reserved.</p>
     </div>
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -43,19 +43,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
-  <url>
-    <loc>https://nextmetro.live/terms/</loc>
-    <lastmod>2026-03-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.3</priority>
-  </url>
-  <url>
-    <loc>https://nextmetro.live/privacy/</loc>
-    <lastmod>2026-03-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.3</priority>
-  </url>
-  <url>
+<url>
     <loc>https://nextmetro.live/crisis/</loc>
     <lastmod>2026-03-14</lastmod>
     <changefreq>monthly</changefreq>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,36 +3,37 @@
   <!-- ===== Core Pages ===== -->
   <url>
     <loc>https://nextmetro.live/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://nextmetro.live/alerts/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>always</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nextmetro.live/elevators/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>always</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nextmetro.live/fares/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nextmetro.live/hours/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nextmetro.live/transfers/</loc>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -41,6 +42,18 @@
     <lastmod>2026-03-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://nextmetro.live/terms/</loc>
+    <lastmod>2026-03-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://nextmetro.live/privacy/</loc>
+    <lastmod>2026-03-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
   </url>
   <url>
     <loc>https://nextmetro.live/crisis/</loc>
@@ -52,37 +65,37 @@
   <!-- ===== Line Pages ===== -->
   <url>
     <loc>https://nextmetro.live/lines/red/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nextmetro.live/lines/blue/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nextmetro.live/lines/orange/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nextmetro.live/lines/green/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nextmetro.live/lines/yellow/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://nextmetro.live/lines/silver/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>

--- a/public/station/archives/index.html
+++ b/public/station/archives/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Archives-Navy Memorial-Penn Quarter Station — Real-Time Arrivals, Fares & Info | NextMetro</title>
-  <meta name="description" content="Live train arrivals for Archives-Navy Memorial-Penn Quarter Metro station on the Green and Yellow lines in Washington, DC. Real-time PIDS board, fare calculator, elevator status, and service alerts." />
+  <meta name="description" content="Live arrivals for Archives-Navy Memorial-Penn Quarter station on the Green and Yellow lines in DC. PIDS board, fare calculator, elevator status, and alerts." />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://nextmetro.live/station/archives/" />
 

--- a/public/station/eastern-market/index.html
+++ b/public/station/eastern-market/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Eastern Market Station — Real-Time Arrivals, Fares & Info | NextMetro</title>
-  <meta name="description" content="Live train arrivals for Eastern Market Metro station on the Orange, Blue, and Silver lines in Washington, DC. Real-time PIDS board, fare calculator, elevator status, and service alerts." />
+  <meta name="description" content="Live arrivals for Eastern Market Metro station on the Orange, Blue, and Silver lines in DC. PIDS board, fare calculator, elevator status, and alerts." />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://nextmetro.live/station/eastern-market/" />
 

--- a/public/station/potomac-yard/index.html
+++ b/public/station/potomac-yard/index.html
@@ -426,7 +426,7 @@
           <span class="adjacent-line-badge adjacent-line-badge--yellow">Yellow Line</span>
         </div>
         <div class="adjacent-body">
-          <a href="/station/ronald-reagan-washington-national-airport/" class="adjacent-station adjacent-station--prev">
+          <a href="/station/reagan-airport/" class="adjacent-station adjacent-station--prev">
             <span class="adjacent-direction">
               <i class="ri-arrow-left-s-line" aria-hidden="true"></i>
               Toward Franconia / Mt Vernon Sq
@@ -436,7 +436,7 @@
           <div class="adjacent-divider">
             <span class="adjacent-current-dot"></span>
           </div>
-          <a href="/station/braddock-road/" class="adjacent-station adjacent-station--next">
+          <a href="/" class="adjacent-station adjacent-station--next">
             <span class="adjacent-direction">
               Toward Huntington / Greenbelt
               <i class="ri-arrow-right-s-line" aria-hidden="true"></i>

--- a/public/station/washington-dulles/index.html
+++ b/public/station/washington-dulles/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Washington Dulles International Airport Station — Real-Time Arrivals, Fares & Info | NextMetro</title>
-  <meta name="description" content="Live train arrivals for Washington Dulles International Airport Metro station on the Silver Line in Dulles, VA. Real-time PIDS board, fare calculator, elevator status, and service alerts for WMATA Metrorail." />
+  <meta name="description" content="Live arrivals for Washington Dulles Airport Metro station on the Silver Line in Dulles, VA. PIDS board, fare calculator, elevator status, and service alerts." />
   <meta name="robots" content="index, follow" />
 <link rel="canonical" href="https://nextmetro.live/station/washington-dulles/" />
 

--- a/public/terms/index.html
+++ b/public/terms/index.html
@@ -97,7 +97,7 @@
   <div class="legal-page">
     <span class="legal-label">Legal</span>
     <h1 class="legal-title">Terms of Service</h1>
-    <p class="legal-meta">Effective Date: March 10, 2026 &middot; Last Updated: March 10, 2026</p>
+    <p class="legal-meta">Effective Date: March 10, 2026 &middot; Last Updated: March 17, 2026</p>
 
     <div class="legal-callout">
       <h2 class="legal-callout-heading">The Short Version</h2>
@@ -350,7 +350,7 @@
     </div>
 
     <div class="legal-footer-note">
-      <p>Last Updated: March 10, 2026</p>
+      <p>Last Updated: March 17, 2026</p>
       <p>&copy; 2026 NextMetro. All rights reserved.</p>
     </div>
   </div>

--- a/public/transfers/index.html
+++ b/public/transfers/index.html
@@ -552,7 +552,8 @@
     <!-- Disclaimer -->
     <div class="line-disclaimer">
       <p>
-        Transfer information is based on the current <a href="https://wmata.com/schedules/maps/upload/system-map-rail.pdf" target="_blank" rel="noopener">WMATA system map</a> and is subject to change during track work or service disruptions. For the most current service information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with WMATA.
+        <strong>WMATA Transit information provided on this site is subject to change without notice.</strong>
+        Transfer information is based on the current <a href="https://wmata.com/schedules/maps/upload/system-map-rail.pdf" target="_blank" rel="noopener">WMATA system map</a> and is subject to change during track work or service disruptions. For the most current service information, visit <a href="https://www.wmata.com/" target="_blank" rel="noopener">wmata.com</a>. NextMetro is not affiliated with, endorsed by, or connected to WMATA.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
This PR adds required WMATA API data disclaimers across the NextMetro application to comply with the WMATA API Developer Agreement. The disclaimer emphasizes that transit information is subject to change and clarifies that NextMetro is not affiliated with WMATA.

## Key Changes

- **Dynamic disclaimer injection on home page**: Added `injectWmataDisclaimer()` function in `app.js` that dynamically injects a styled disclaimer below the PIDS boards on the main station view
- **Disclaimer styling**: Created `.wmata-data-disclaimer` CSS class with proper formatting, including bold primary text and secondary color for supporting text
- **Static disclaimers on all pages**: Updated disclaimer text on all content pages (alerts, elevators, fares, hours, line pages, transfers) to include the required bold statement: "WMATA Transit information provided on this site is subject to change without notice."
- **Consistent messaging**: Standardized language across all disclaimers to clarify NextMetro is "not affiliated with, endorsed by, or connected to WMATA"
- **Meta description update**: Removed "accurate" from homepage meta description and updated homepage copy to say "Fast, free" instead of "Fast, accurate" to align with disclaimer messaging

## Implementation Details

- The dynamic disclaimer is injected once on page load and positioned immediately after the `lastUpdatedEl` element for visibility near real-time data
- Duplicate injection is prevented via a querySelector check for the `.wmata-data-disclaimer` class
- All static disclaimers use consistent styling and are placed in prominent locations (end of content sections)
- The disclaimer styling respects the existing design system variables (spacing, colors, typography)

https://claude.ai/code/session_01TM4VxfjFNpd8eZfWtdeLQH