### PR TITLE
Add hero images to station pages

### DIFF
--- a/public/css/transfers.css
+++ b/public/css/transfers.css
@@ -5,7 +5,7 @@
   padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
   border-bottom: 1px solid var(--nm-border-subtle);
   background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.65)),
-    url('/images/transfer-stations-hero.webp') center / cover no-repeat;
+    url('/images/transfer-station-hero.webp') center / cover no-repeat;
   background-color: var(--nm-surface);
 }
 

--- a/public/station/arlington-cemetery/index.html
+++ b/public/station/arlington-cemetery/index.html
@@ -151,7 +151,10 @@
   </div>
 
   <!-- Hero / Station Header -->
-  <section class="hero" id="hero">
+  <section class="hero hero--has-image" id="hero">
+    <div class="hero__image" aria-hidden="true">
+      <img src="/images/station-specific/arlington-cemetery.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
+    </div>
     <div class="hero-inner">
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">Arlington Cemetery</h1>

--- a/public/station/court-house/index.html
+++ b/public/station/court-house/index.html
@@ -150,7 +150,10 @@
   </div>
 
   <!-- Hero / Station Header -->
-  <section class="hero" id="hero">
+  <section class="hero hero--has-image" id="hero">
+    <div class="hero__image" aria-hidden="true">
+      <img src="/images/station-specific/courthouse-station.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
+    </div>
     <div class="hero-inner">
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">Court House</h1>

--- a/public/station/crystal-city/index.html
+++ b/public/station/crystal-city/index.html
@@ -151,7 +151,10 @@
   </div>
 
   <!-- Hero / Station Header -->
-  <section class="hero" id="hero">
+  <section class="hero hero--has-image" id="hero">
+    <div class="hero__image" aria-hidden="true">
+      <img src="/images/station-specific/crystal-city.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
+    </div>
     <div class="hero-inner">
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">Crystal City</h1>

--- a/public/station/tysons/index.html
+++ b/public/station/tysons/index.html
@@ -150,7 +150,10 @@
   </div>
 
   <!-- Hero / Station Header -->
-  <section class="hero" id="hero">
+  <section class="hero hero--has-image" id="hero">
+    <div class="hero__image" aria-hidden="true">
+      <img src="/images/station-specific/tysons-corner.webp" alt="" width="1200" height="400" loading="eager" onerror="this.dataset.error='1'" />
+    </div>
     <div class="hero-inner">
       <span class="hero-label">Station</span>
       <h1 class="hero-station-name" id="hero-station-name">Tysons</h1>


### PR DESCRIPTION
## Summary
Added hero section background images to four station pages (Arlington Cemetery, Court House, Crystal City, and Tysons) to enhance visual presentation.

## Changes
- Added `hero--has-image` modifier class to hero sections
- Inserted new `hero__image` container with station-specific WebP images
- Images are 1200x400px with eager loading and error handling
- Images are marked as decorative with `aria-hidden="true"` and empty alt text

## Implementation Details
- Each station now displays a unique background image in the hero section
- Images use WebP format for optimal performance
- `loading="eager"` ensures images load immediately with the page
- `onerror` handler provides graceful degradation if images fail to load
- Decorative images are properly hidden from screen readers

https://claude.ai/code/session_01PSnNL8DUfcY3aALniwbDZm