### PR TITLE
Add Umami analytics tracking to all pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ NextMetro is an independent, real-time dashboard for the D.C. Metro system. It p
 | **Frontend** | Vanilla HTML5, CSS, JavaScript |
 | **Backend** | Cloudflare Workers (API proxy + caching) |
 | **Data Source** | [WMATA Real-Time Rail API](https://developer.wmata.com/) |
+| **Analytics** | [Umami](https://umami.is/) (privacy-focused, cookie-free) |
 | **Typography** | [Rajdhani](https://fonts.google.com/specimen/Rajdhani) (Google Fonts) |
 | **Hosting** | Cloudflare (Workers + static assets at the edge) |
 

--- a/public/404.html
+++ b/public/404.html
@@ -43,6 +43,7 @@
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/remixicon@4.6.0/fonts/remixicon.css" rel="stylesheet" integrity="sha256-MblAFgCXnFAJlRJnqJqOjRfz0ODAP+6LxfGQEK7g1o=" crossorigin="anonymous" />
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/500.html
+++ b/public/500.html
@@ -43,6 +43,7 @@
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/remixicon@4.6.0/fonts/remixicon.css" rel="stylesheet" integrity="sha256-MblAFgCXnFAJlRJnqJqOjRfz0ODAP+6LxfGQEK7g1o=" crossorigin="anonymous" />
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -59,6 +59,7 @@
     }
   }
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/alerts/index.html
+++ b/public/alerts/index.html
@@ -140,6 +140,7 @@
     ]
   }
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/crisis/index.html
+++ b/public/crisis/index.html
@@ -59,6 +59,7 @@
     }
   }
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/elevators/index.html
+++ b/public/elevators/index.html
@@ -124,6 +124,7 @@
     ]
   }
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -106,6 +106,7 @@
     ]
   }
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/hours/index.html
+++ b/public/hours/index.html
@@ -115,6 +115,7 @@
     ]
   }
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/index.html
+++ b/public/index.html
@@ -72,6 +72,7 @@
     "description": "Next arrival information for the Washington DC Metro system"
   }
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/lines/blue/index.html
+++ b/public/lines/blue/index.html
@@ -208,7 +208,8 @@
 				}
 			]
 		</script>
-	</head>
+	  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
+</head>
 	<body>
 		<a href="#main-content" class="skip-link">Skip to main content</a>
 

--- a/public/lines/green/index.html
+++ b/public/lines/green/index.html
@@ -198,6 +198,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/lines/orange/index.html
+++ b/public/lines/orange/index.html
@@ -198,6 +198,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/lines/red/index.html
+++ b/public/lines/red/index.html
@@ -198,6 +198,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/lines/silver/index.html
+++ b/public/lines/silver/index.html
@@ -198,6 +198,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/lines/yellow/index.html
+++ b/public/lines/yellow/index.html
@@ -198,6 +198,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -39,6 +39,7 @@
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/remixicon@4.6.0/fonts/remixicon.css" rel="stylesheet" integrity="sha256-MblAFgCXnFAJlRJnqJqOjRfz0ODAP+6LxfGQEK7g1o=" crossorigin="anonymous" />
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -100,11 +100,11 @@
   <div class="legal-page">
     <span class="legal-label">Legal</span>
     <h1 class="legal-title">Privacy Policy</h1>
-    <p class="legal-meta">Effective Date: March 10, 2026 &middot; Last Updated: March 17, 2026</p>
+    <p class="legal-meta">Effective Date: March 10, 2026 &middot; Last Updated: April 7, 2026</p>
 
     <div class="legal-callout">
       <h2 class="legal-callout-heading">The Short Version</h2>
-      <p>NextMetro is a transit information app. We collect minimal data &mdash; basically just standard server logs and whatever analytics we use to understand traffic. We don't sell your data. We're not affiliated with WMATA. If you're in the EU, California, or other places with strong privacy laws, you have rights we respect.</p>
+      <p>NextMetro is a transit information app. We collect minimal data &mdash; basically just standard server logs and privacy-focused analytics to understand traffic. Our analytics are cookie-free, do not track you across sites, and do not collect personal information. We don't sell your data. We're not affiliated with WMATA. If you're in the EU, California, or other places with strong privacy laws, you have rights we respect.</p>
       <p>We use Google Fonts, which means Google gets your IP address when you load our site. We're working on self-hosting fonts to eliminate this.</p>
     </div>
 
@@ -271,7 +271,20 @@
       <p><strong>More information:</strong> See <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener noreferrer">Cloudflare's Privacy Policy</a>.</p>
 
       <h3>5.3 Analytics</h3>
-      <p>We currently do not use third-party analytics services. We rely only on standard server logs.</p>
+      <p><strong>What it is:</strong> NextMetro uses a privacy-focused, cookie-free analytics service to understand how visitors use the Service.</p>
+      <p><strong>What it collects:</strong> Aggregate, non-personal data including:</p>
+      <ul class="legal-list">
+        <li>Page views and referring URLs</li>
+        <li>Browser and device type</li>
+        <li>Country of origin (derived from IP address)</li>
+      </ul>
+      <p><strong>What it does NOT collect:</strong></p>
+      <ul class="legal-list">
+        <li>Personal information or IP addresses</li>
+        <li>Cookies or persistent identifiers</li>
+        <li>Cross-site tracking data</li>
+      </ul>
+      <p><strong>Compliance:</strong> Our analytics service is GDPR, CCPA, and PECR compliant. It does not require a cookie consent banner because it does not use cookies or collect personal data.</p>
 
       <h3>5.4 WMATA API</h3>
       <p><strong>What it is:</strong> Transit data displayed in NextMetro is fetched from WMATA's public API.</p>
@@ -315,7 +328,7 @@
       <p>Note that disabling cookies may affect the functionality of the Service.</p>
 
       <h3>6.5 Third-Party Cookies</h3>
-      <p>Third-party services we use (such as Google Fonts or analytics providers) may set their own cookies. We do not control these cookies. Please refer to the respective third-party privacy policies for more information.</p>
+      <p>Third-party services we use (such as Google Fonts) may set their own cookies. We do not control these cookies. Please refer to the respective third-party privacy policies for more information. Note that our analytics service does not use cookies.</p>
 
       <!-- Section 7 -->
       <h2>7. Data Retention</h2>
@@ -585,7 +598,7 @@
     </div>
 
     <div class="legal-footer-note">
-      <p>Last Updated: March 17, 2026</p>
+      <p>Last Updated: April 7, 2026</p>
       <p>&copy; 2026 NextMetro. All rights reserved.</p>
     </div>
 

--- a/public/station/addison-road/index.html
+++ b/public/station/addison-road/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/anacostia/index.html
+++ b/public/station/anacostia/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/archives/index.html
+++ b/public/station/archives/index.html
@@ -134,6 +134,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/arlington-cemetery/index.html
+++ b/public/station/arlington-cemetery/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/ashburn/index.html
+++ b/public/station/ashburn/index.html
@@ -141,6 +141,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/ballston/index.html
+++ b/public/station/ballston/index.html
@@ -132,6 +132,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/benning-road/index.html
+++ b/public/station/benning-road/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/bethesda/index.html
+++ b/public/station/bethesda/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/braddock-road/index.html
+++ b/public/station/braddock-road/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/branch-ave/index.html
+++ b/public/station/branch-ave/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/brookland-cua/index.html
+++ b/public/station/brookland-cua/index.html
@@ -173,6 +173,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/capitol-heights/index.html
+++ b/public/station/capitol-heights/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/capitol-south/index.html
+++ b/public/station/capitol-south/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/cheverly/index.html
+++ b/public/station/cheverly/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/clarendon/index.html
+++ b/public/station/clarendon/index.html
@@ -132,6 +132,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/cleveland-park/index.html
+++ b/public/station/cleveland-park/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/college-park/index.html
+++ b/public/station/college-park/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/columbia-heights/index.html
+++ b/public/station/columbia-heights/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/congress-heights/index.html
+++ b/public/station/congress-heights/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/court-house/index.html
+++ b/public/station/court-house/index.html
@@ -132,6 +132,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/crystal-city/index.html
+++ b/public/station/crystal-city/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/dca-national-airport/index.html
+++ b/public/station/dca-national-airport/index.html
@@ -134,6 +134,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/deanwood/index.html
+++ b/public/station/deanwood/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/downtown-largo/index.html
+++ b/public/station/downtown-largo/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/dunn-loring/index.html
+++ b/public/station/dunn-loring/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/dupont-circle/index.html
+++ b/public/station/dupont-circle/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/east-falls-church/index.html
+++ b/public/station/east-falls-church/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/eastern-market/index.html
+++ b/public/station/eastern-market/index.html
@@ -134,6 +134,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/eisenhower-ave/index.html
+++ b/public/station/eisenhower-ave/index.html
@@ -134,6 +134,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/farragut-north/index.html
+++ b/public/station/farragut-north/index.html
@@ -134,6 +134,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/farragut-west/index.html
+++ b/public/station/farragut-west/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/federal-center-sw/index.html
+++ b/public/station/federal-center-sw/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/federal-triangle/index.html
+++ b/public/station/federal-triangle/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/foggy-bottom/index.html
+++ b/public/station/foggy-bottom/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/forest-glen/index.html
+++ b/public/station/forest-glen/index.html
@@ -180,6 +180,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/fort-totten/index.html
+++ b/public/station/fort-totten/index.html
@@ -173,6 +173,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/franconia-springfield/index.html
+++ b/public/station/franconia-springfield/index.html
@@ -134,6 +134,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/friendship-heights/index.html
+++ b/public/station/friendship-heights/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/gallery-place/index.html
+++ b/public/station/gallery-place/index.html
@@ -134,6 +134,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/georgia-ave-petworth/index.html
+++ b/public/station/georgia-ave-petworth/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/glenmont/index.html
+++ b/public/station/glenmont/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/greenbelt/index.html
+++ b/public/station/greenbelt/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/greensboro/index.html
+++ b/public/station/greensboro/index.html
@@ -132,6 +132,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/grosvenor-strathmore/index.html
+++ b/public/station/grosvenor-strathmore/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/herndon/index.html
+++ b/public/station/herndon/index.html
@@ -178,6 +178,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/huntington/index.html
+++ b/public/station/huntington/index.html
@@ -134,6 +134,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/hyattsville-crossing/index.html
+++ b/public/station/hyattsville-crossing/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/innovation-center/index.html
+++ b/public/station/innovation-center/index.html
@@ -178,6 +178,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/judiciary-square/index.html
+++ b/public/station/judiciary-square/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/king-street/index.html
+++ b/public/station/king-street/index.html
@@ -134,6 +134,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/landover/index.html
+++ b/public/station/landover/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/lenfant-plaza/index.html
+++ b/public/station/lenfant-plaza/index.html
@@ -134,6 +134,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/loudoun-gateway/index.html
+++ b/public/station/loudoun-gateway/index.html
@@ -178,6 +178,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/mclean/index.html
+++ b/public/station/mclean/index.html
@@ -132,6 +132,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/mcpherson-square/index.html
+++ b/public/station/mcpherson-square/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/medical-center/index.html
+++ b/public/station/medical-center/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/metro-center/index.html
+++ b/public/station/metro-center/index.html
@@ -173,6 +173,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/minnesota-ave/index.html
+++ b/public/station/minnesota-ave/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/morgan-boulevard/index.html
+++ b/public/station/morgan-boulevard/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/mt-vernon-sq/index.html
+++ b/public/station/mt-vernon-sq/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/navy-yard-ballpark/index.html
+++ b/public/station/navy-yard-ballpark/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/naylor-road/index.html
+++ b/public/station/naylor-road/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/new-carrollton/index.html
+++ b/public/station/new-carrollton/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/noma/index.html
+++ b/public/station/noma/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/north-bethesda/index.html
+++ b/public/station/north-bethesda/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/pentagon-city/index.html
+++ b/public/station/pentagon-city/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/pentagon/index.html
+++ b/public/station/pentagon/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/potomac-ave/index.html
+++ b/public/station/potomac-ave/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/potomac-yard/index.html
+++ b/public/station/potomac-yard/index.html
@@ -178,6 +178,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/reston-town-center/index.html
+++ b/public/station/reston-town-center/index.html
@@ -186,6 +186,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/rhode-island-ave/index.html
+++ b/public/station/rhode-island-ave/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/rockville/index.html
+++ b/public/station/rockville/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/rosslyn/index.html
+++ b/public/station/rosslyn/index.html
@@ -132,6 +132,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/shady-grove/index.html
+++ b/public/station/shady-grove/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/shaw-howard-u/index.html
+++ b/public/station/shaw-howard-u/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/silver-spring/index.html
+++ b/public/station/silver-spring/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/smithsonian/index.html
+++ b/public/station/smithsonian/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/southern-ave/index.html
+++ b/public/station/southern-ave/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/spring-hill/index.html
+++ b/public/station/spring-hill/index.html
@@ -124,6 +124,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/public/station/stadium-armory/index.html
+++ b/public/station/stadium-armory/index.html
@@ -134,6 +134,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/suitland/index.html
+++ b/public/station/suitland/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/takoma/index.html
+++ b/public/station/takoma/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/tenleytown-au/index.html
+++ b/public/station/tenleytown-au/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/twinbrook/index.html
+++ b/public/station/twinbrook/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/tysons/index.html
+++ b/public/station/tysons/index.html
@@ -132,6 +132,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/u-street/index.html
+++ b/public/station/u-street/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/union-station/index.html
+++ b/public/station/union-station/index.html
@@ -147,6 +147,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/van-dorn-street/index.html
+++ b/public/station/van-dorn-street/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/van-ness-udc/index.html
+++ b/public/station/van-ness-udc/index.html
@@ -133,6 +133,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/vienna/index.html
+++ b/public/station/vienna/index.html
@@ -132,6 +132,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/virginia-square/index.html
+++ b/public/station/virginia-square/index.html
@@ -132,6 +132,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/washington-dulles/index.html
+++ b/public/station/washington-dulles/index.html
@@ -186,6 +186,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/waterfront/index.html
+++ b/public/station/waterfront/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/west-falls-church/index.html
+++ b/public/station/west-falls-church/index.html
@@ -132,6 +132,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/west-hyattsville/index.html
+++ b/public/station/west-hyattsville/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/wheaton/index.html
+++ b/public/station/wheaton/index.html
@@ -180,6 +180,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/station/wiehle-reston-east/index.html
+++ b/public/station/wiehle-reston-east/index.html
@@ -124,6 +124,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/public/station/woodley-park/index.html
+++ b/public/station/woodley-park/index.html
@@ -172,6 +172,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/stations/index.html
+++ b/public/stations/index.html
@@ -703,6 +703,7 @@
     }
   ]
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/terms/index.html
+++ b/public/terms/index.html
@@ -39,6 +39,7 @@
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/remixicon@4.6.0/fonts/remixicon.css" rel="stylesheet" integrity="sha256-MblAFgCXnFAJlRJnqJqOjRfz0ODAP+6LxfGQEK7g1o=" crossorigin="anonymous" />
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/public/transfers/index.html
+++ b/public/transfers/index.html
@@ -155,6 +155,7 @@
     ]
   }
   </script>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>
 </head>
 <body>
 

--- a/src/index.js
+++ b/src/index.js
@@ -369,7 +369,7 @@ function addSecurityHeaders(response) {
 	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
 	response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
 	response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
-	response.headers.set('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'");
+	response.headers.set('Content-Security-Policy', "default-src 'self'; script-src 'self' https://cloud.umami.is; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data:; connect-src 'self' https://cloud.umami.is; frame-ancestors 'none'");
 }
 
 // ==============================


### PR DESCRIPTION
## Summary
This PR integrates Umami analytics tracking across the entire application by adding the Umami script to all HTML pages and updating the Content Security Policy to allow the Umami domain.

## Key Changes
- **Analytics Script**: Added `<script defer src="https://cloud.umami.is/script.js" data-website-id="cd3911ec-9121-4bb1-8153-918b1f40e862"></script>` to the `<head>` section of all HTML pages (100+ pages including station pages, line pages, and utility pages)
- **Security Policy Update**: Modified the Content Security Policy in `src/index.js` to allow scripts from `https://cloud.umami.is` by updating the `script-src` directive from `'self'` to `'self' https://cloud.umami.is`

## Implementation Details
- The Umami script is loaded with the `defer` attribute to ensure non-blocking page load
- The same website ID (`cd3911ec-9121-4bb1-8153-918b1f40e862`) is used consistently across all pages
- The CSP update maintains all existing security restrictions while explicitly allowing the Umami analytics domain
- Changes are applied uniformly across all page types: main pages, station pages, line pages, and error pages

https://claude.ai/code/session_01So3HyujYoqvnsrLE8VcxME