### PR TITLE
Separate elevator/escalator alerts to dedicated page

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ NextMetro is an independent, real-time dashboard for the D.C. Metro system. It p
 |------|--------------|
 | **[Station Pages](https://nextmetro.live/station/metro-center/)** | PIDS arrival board, system status, service alerts, elevator/escalator status, fare calculator. Transfer stations (Metro Center, Gallery Place) show dual side-by-side boards — one per physical platform. |
 | **[Line Pages](https://nextmetro.live/lines/red/)** | All stations on the line with transfer/parking badges, real-time status, service hours, frequency info, and FAQ. All 6 lines covered. |
-| **[Service Alerts](https://nextmetro.live/alerts/)** | Every active WMATA rail incident + elevator/escalator outage, severity-sorted, auto-refreshing. |
+| **[Service Alerts](https://nextmetro.live/alerts/)** | Active WMATA rail incidents — delays, closures, single tracking, advisories — severity-sorted and auto-refreshing. |
 | **[Elevator & Escalator Status](https://nextmetro.live/elevators/)** | System-wide outage tracker grouped by station, filterable by type and line. |
 | **[Fare Calculator](https://nextmetro.live/fares/)** | Peak/off-peak/senior pricing between any two stations with travel time estimates and commute cost projections. |
 | **[Hours & Schedules](https://nextmetro.live/hours/)** | Operating hours, frequency tables, holiday schedules. |
@@ -86,7 +86,7 @@ This project has been built iteratively from a React prototype to a production-g
 | **Jun 2025** | **v2.0 — Full WMATA integration** | Rewrote from React to vanilla HTML/CSS/JS. Express backend proxy, real-time arrivals, fare calculator, system status. Deployed on Netlify + Render. |
 | **Feb 2026** | **Cloudflare migration** | Moved entire stack to Cloudflare Workers. Single deployment for API proxy + static assets. Eliminated cold starts. |
 | **Feb 2026** | **v2.1 — Line pages** | 6 dedicated line pages with station lists, transfer badges, parking indicators, service info, and FAQ sections. |
-| **Feb 2026** | **v2.2 — Alerts page** | Unified rail incidents + elevator/escalator outages. Severity sorting, SpecialAnnouncement schema. |
+| **Feb 2026** | **v2.2 — Alerts page** | Rail service alerts with severity sorting and SpecialAnnouncement schema. Elevator/escalator outages split to dedicated page. |
 | **Feb 2026** | **v2.3 — Elevator status** | Station-grouped outage view with dual filter system. Accessibility-first sorting (elevator outages surface first). |
 | **Mar 2026** | **v2.5 — Site-wide audit** | WCAG compliance pass, skip navigation on all pages, Schema.org structured data everywhere, meta/OG tags audit, static status bar. |
 | **Mar 2026** | **v2.6 — Station pages** | 5 dedicated station pages including dual-PIDS transfer stations (Metro Center, Gallery Place). Search navigation. |

--- a/public/alerts/index.html
+++ b/public/alerts/index.html
@@ -205,13 +205,6 @@
     </div>
   </section>
 
-  <!-- System Status Summary (below hero) -->
-  <div class="alerts-status-wrap">
-    <div class="alerts-status-bar animate-in d2" id="alerts-status-bar">
-      <!-- Rendered by JS -->
-    </div>
-  </div>
-
   <!-- Main Content -->
   <main id="main-content">
 
@@ -225,6 +218,13 @@
 
     <div class="alerts-page">
     <div class="alerts-page-inner">
+
+      <!-- System Status Summary -->
+      <div class="alerts-status-bar animate-in d2" id="alerts-status-bar">
+        <!-- Rendered by JS -->
+      </div>
+
+      <p class="alerts-intro">Real-time service alerts for all six Metrorail lines. Data is sourced from the WMATA Incidents API and refreshes automatically every 30 seconds. For elevator and escalator outages, visit the <a href="/elevators/">Elevator &amp; Escalator Status</a> page.</p>
 
       <!-- Controls Bar -->
       <div class="alerts-controls animate-in d1">

--- a/public/alerts/index.html
+++ b/public/alerts/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>DC Metro Service Alerts &amp; Delays | NextMetro</title>
-  <meta name="description" id="meta-description" content="DC Metro service alerts: train delays, station closures, single tracking, and elevator outages. Updated from WMATA." />
+  <meta name="description" id="meta-description" content="DC Metro service alerts: train delays, station closures, single tracking, and service advisories. Updated from WMATA." />
   <link rel="canonical" href="https://nextmetro.live/alerts/" />
   <link rel="stylesheet" href="/css/styles.css" />
   <link rel="stylesheet" href="/css/alerts-page.css" />
@@ -19,7 +19,7 @@
 
   <!-- Open Graph -->
   <meta property="og:title" content="DC Metro Service Alerts &amp; Delays | NextMetro" />
-  <meta property="og:description" content="DC Metrorail alerts: train delays, closures, single tracking, elevator and escalator outages. Updated from WMATA." />
+  <meta property="og:description" content="DC Metrorail alerts: train delays, closures, single tracking, and service advisories. Updated from WMATA." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://nextmetro.live/alerts/" />
   <meta property="og:site_name" content="NextMetro" />
@@ -32,7 +32,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="DC Metro Service Alerts &amp; Delays | NextMetro" />
-  <meta name="twitter:description" content="DC Metrorail alerts: train delays, closures, single tracking, elevator and escalator outages. Updated from WMATA." />
+  <meta name="twitter:description" content="DC Metrorail alerts: train delays, closures, single tracking, and service advisories. Updated from WMATA." />
   <meta name="twitter:image" content="https://nextmetro.live/images/og/homepage-utility/og-alerts.png" />
 
   <!-- Favicon -->
@@ -200,15 +200,17 @@
   <section class="alerts-hero">
     <div class="alerts-hero-inner">
       <span class="alerts-hero-label">Live Status</span>
-      <h1 class="alerts-hero-title">DC Metro Alerts &amp; Outages</h1>
-      <p class="alerts-hero-subtitle" id="alerts-subtitle">Train delays, station closures, single tracking, and elevator &amp; escalator outages — updated every 30 seconds.</p>
-
-      <!-- System Status Summary -->
-      <div class="alerts-status-bar animate-in d2" id="alerts-status-bar">
-        <!-- Rendered by JS -->
-      </div>
+      <h1 class="alerts-hero-title">DC Metro Alerts</h1>
+      <p class="alerts-hero-subtitle" id="alerts-subtitle">Train delays, station closures, single tracking, and service advisories — updated every 30 seconds.</p>
     </div>
   </section>
+
+  <!-- System Status Summary (below hero) -->
+  <div class="alerts-status-wrap">
+    <div class="alerts-status-bar animate-in d2" id="alerts-status-bar">
+      <!-- Rendered by JS -->
+    </div>
+  </div>
 
   <!-- Main Content -->
   <main id="main-content">
@@ -324,9 +326,9 @@
         </details>
 
         <details class="line-faq-item">
-          <summary class="line-faq-question">Why are there so many elevator and escalator outages?</summary>
+          <summary class="line-faq-question">Where can I find elevator and escalator outages?</summary>
           <div class="line-faq-answer">
-            <p>The DC Metro system has over 600 escalators and 300 elevators — one of the largest collections of any transit system in the world. Many of these units were installed when the system opened between 1976 and 2001 and have experienced decades of heavy use, weather exposure (many are outdoor units), and the unique engineering challenge of moving riders through the deepest stations in North America. WMATA is in the process of a multi-year capital program to replace and modernize escalators and elevators across the system. Outages are reported in real time through the WMATA Incidents API, which is what powers the alerts on this page.</p>
+            <p>Elevator and escalator outages have their own dedicated page at <a href="/elevators/">Elevator &amp; Escalator Outages</a>. That page shows real-time outage status for every station, filterable by line and unit type, with details on each affected unit. This alerts page focuses on rail service disruptions — delays, closures, single tracking, and advisories.</p>
           </div>
         </details>
 
@@ -347,7 +349,7 @@
         <details class="line-faq-item">
           <summary class="line-faq-question">How often are alerts updated on this page?</summary>
           <div class="line-faq-answer">
-            <p>This page polls both the WMATA Rail Incidents API and the Elevator/Escalator Incidents API every 30 seconds. Rail incident data (delays, advisories, closures, single tracking) comes from one endpoint, and elevator/escalator outage data comes from another. Both are fetched in parallel so the page always shows the latest system-wide picture. The status bar at the top shows per-line status (Normal, Advisory, or Delays) based on active rail incidents, and the ticker scrolls real-time line status across the top of the page.</p>
+            <p>This page polls the WMATA Rail Incidents API every 30 seconds for the latest delays, advisories, closures, and single tracking alerts. The status bar shows per-line status (Normal, Advisory, or Delays) based on active incidents, and the ticker scrolls real-time line status across the top of the page. For elevator and escalator outages, see the dedicated <a href="/elevators/">Elevator &amp; Escalator Outages</a> page.</p>
           </div>
         </details>
 
@@ -368,7 +370,7 @@
         <details class="line-faq-item">
           <summary class="line-faq-question">Does NextMetro show bus alerts or only Metrorail?</summary>
           <div class="line-faq-answer">
-            <p>NextMetro currently shows Metrorail alerts only — this includes all six rail lines (Red, Orange, Blue, Green, Yellow, and Silver) plus system-wide elevator and escalator outages at rail stations. Bus service alerts (Metrobus) are available through WMATA's separate Bus Incidents API but are not yet integrated into NextMetro. For Metrobus alerts, check <a href="https://www.wmata.com/service/bus/" target="_blank" rel="noopener noreferrer">WMATA's bus status page</a>.</p>
+            <p>NextMetro currently shows Metrorail alerts only — this includes all six rail lines (Red, Orange, Blue, Green, Yellow, and Silver). Elevator and escalator outages are shown on a <a href="/elevators/">separate dedicated page</a>. Bus service alerts (Metrobus) are available through WMATA's separate Bus Incidents API but are not yet integrated into NextMetro. For Metrobus alerts, check <a href="https://www.wmata.com/service/bus/" target="_blank" rel="noopener noreferrer">WMATA's bus status page</a>.</p>
           </div>
         </details>
 

--- a/public/css/alerts-page.css
+++ b/public/css/alerts-page.css
@@ -39,8 +39,11 @@
   margin-bottom: var(--nm-space-sm);
 }
 
-.alerts-hero .alerts-status-bar {
-  margin-top: var(--nm-space-lg);
+/* ---- Status Bar Wrapper (below hero) ---- */
+.alerts-status-wrap {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: var(--nm-space-lg) var(--nm-space-lg) 0;
 }
 
 .alerts-hero-subtitle {
@@ -238,11 +241,6 @@
   border-left: 4px solid var(--nm-status-info);
 }
 
-.alerts-card-severity.severity-facility {
-  background-color: rgba(160, 160, 160, 0.06);
-  border-left: 4px solid var(--nm-text-muted);
-}
-
 .alerts-card-icon {
   display: inline-flex;
   flex-shrink: 0;
@@ -260,10 +258,6 @@
 
 .severity-advisory .alerts-card-icon {
   color: var(--nm-status-info);
-}
-
-.severity-facility .alerts-card-icon {
-  color: var(--nm-text-muted);
 }
 
 .alerts-card-severity-label {
@@ -287,10 +281,6 @@
 
 .severity-advisory .alerts-card-severity-label {
   color: var(--nm-status-info);
-}
-
-.severity-facility .alerts-card-severity-label {
-  color: var(--nm-text-muted);
 }
 
 .alerts-card-time {
@@ -333,25 +323,6 @@
   height: 8px;
   border-radius: 50% !important;
   flex-shrink: 0;
-}
-
-.alert-station-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
-  border: 1px solid var(--nm-border);
-  font-family: var(--nm-font);
-  font-weight: 600;
-  font-size: 0.75rem;
-  color: var(--nm-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.alert-station-pill svg {
-  flex-shrink: 0;
-  color: var(--nm-text-muted);
 }
 
 .alerts-card-desc {
@@ -510,6 +481,10 @@
 @media (max-width: 768px) {
   .alerts-page {
     padding: var(--nm-space-lg) var(--nm-space-md);
+  }
+
+  .alerts-status-wrap {
+    padding: var(--nm-space-md) var(--nm-space-md) 0;
   }
 
   .alerts-controls {

--- a/public/css/alerts-page.css
+++ b/public/css/alerts-page.css
@@ -8,7 +8,7 @@
   padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
   border-bottom: 1px solid var(--nm-border-subtle);
   background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.65)),
-    url('/images/metro-alerts-hero.webp') center / cover no-repeat;
+    url('/images/pids-display.webp') center / cover no-repeat;
   background-color: var(--nm-surface);
 }
 
@@ -37,13 +37,6 @@
   letter-spacing: 0.04em;
   line-height: 1.1;
   margin-bottom: var(--nm-space-sm);
-}
-
-/* ---- Status Bar Wrapper (below hero) ---- */
-.alerts-status-wrap {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: var(--nm-space-lg) var(--nm-space-lg) 0;
 }
 
 .alerts-hero-subtitle {
@@ -145,11 +138,30 @@
   letter-spacing: 0.1em;
 }
 
+/* ---- Intro Paragraph ---- */
+.alerts-intro {
+  font-family: var(--nm-font);
+  font-weight: 400;
+  font-size: 1rem;
+  color: var(--nm-text-secondary);
+  line-height: 1.65;
+  max-width: 700px;
+}
+
+.alerts-intro a {
+  color: var(--nm-amber);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.alerts-intro a:hover {
+  text-decoration: underline;
+}
+
 /* ---- Status Summary Bar ---- */
 .alerts-status-bar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   background-color: var(--nm-surface);
   border: 1px solid var(--nm-border);
   overflow: hidden;
@@ -160,14 +172,16 @@
   align-items: center;
   gap: 8px;
   padding: 0.6rem 1rem;
-  flex: 1 1 auto;
-  min-width: 140px;
   border-right: 1px solid var(--nm-border-subtle);
   border-bottom: 1px solid var(--nm-border-subtle);
 }
 
-.alerts-status-item:last-child {
+.alerts-status-item:nth-child(3n) {
   border-right: none;
+}
+
+.alerts-status-item:nth-last-child(-n+3) {
+  border-bottom: none;
 }
 
 .alerts-status-dot {
@@ -483,10 +497,6 @@
     padding: var(--nm-space-lg) var(--nm-space-md);
   }
 
-  .alerts-status-wrap {
-    padding: var(--nm-space-md) var(--nm-space-md) 0;
-  }
-
   .alerts-controls {
     flex-direction: column;
     gap: var(--nm-space-sm);
@@ -497,12 +507,23 @@
   }
 
   .alerts-status-bar {
-    flex-direction: column;
+    grid-template-columns: repeat(2, 1fr);
   }
 
-  .alerts-status-item {
-    min-width: unset;
+  .alerts-status-item:nth-child(3n) {
+    border-right: 1px solid var(--nm-border-subtle);
+  }
+
+  .alerts-status-item:nth-child(2n) {
     border-right: none;
+  }
+
+  .alerts-status-item:nth-last-child(-n+3) {
+    border-bottom: 1px solid var(--nm-border-subtle);
+  }
+
+  .alerts-status-item:nth-last-child(-n+2) {
+    border-bottom: none;
   }
 
   .alerts-card-body {

--- a/public/css/alerts-page.css
+++ b/public/css/alerts-page.css
@@ -8,7 +8,7 @@
   padding: var(--nm-space-3xl) var(--nm-space-lg) var(--nm-space-2xl);
   border-bottom: 1px solid var(--nm-border-subtle);
   background: linear-gradient(rgba(10, 10, 10, 0.6), rgba(10, 10, 10, 0.65)),
-    url('/images/pids-display.webp') center / cover no-repeat;
+    url('/images/metro-alerts-hero.webp') 50% 99% / cover no-repeat;
   background-color: var(--nm-surface);
 }
 

--- a/public/js/alerts.js
+++ b/public/js/alerts.js
@@ -1,6 +1,7 @@
 // ==============================
 // NextMetro — Alerts Page
-// All WMATA service alerts: rail incidents + elevator/escalator outages
+// WMATA rail service alerts (delays, closures, advisories, single tracking)
+// Elevator/escalator outages are on the dedicated /elevators/ page
 // Depends on shared.js (loaded first)
 // ==============================
 
@@ -14,8 +15,6 @@ const SEVERITY = {
   'Station Closure': 3,
   'Single Tracking': 4,
   Advisory: 5,
-  Elevator: 7,
-  Escalator: 7,
 };
 
 function getSeverity(incidentType) {
@@ -29,8 +28,6 @@ function getSeverityLabel(incidentType) {
   if (type === 'Alert') return 'Alert';
   if (type === 'Closure' || type === 'Station Closure') return 'Closure';
   if (type === 'Single Tracking') return 'Single Tracking';
-  if (type === 'Elevator') return 'Elevator';
-  if (type === 'Escalator') return 'Escalator';
   return 'Advisory';
 }
 
@@ -39,7 +36,6 @@ function getSeverityClass(label) {
   if (label === 'Alert') return 'severity-alert';
   if (label === 'Closure') return 'severity-closure';
   if (label === 'Single Tracking') return 'severity-caution';
-  if (label === 'Elevator' || label === 'Escalator') return 'severity-facility';
   return 'severity-advisory';
 }
 
@@ -78,35 +74,8 @@ function deduplicateIncidents(incidents) {
   return Array.from(map.values());
 }
 
-// ---- Normalize elevator/escalator incidents into the same shape ----
-function normalizeElevatorIncidents(elevatorIncidents) {
-  return (elevatorIncidents || []).map(function (outage) {
-    var unitType = (outage.UnitType || '').toUpperCase();
-    var label = unitType === 'ELEVATOR' ? 'Elevator' : 'Escalator';
-    var station = outage.StationName || '';
-    var location = outage.LocationDescription || '';
-    var symptom = outage.SymptomDescription || '';
-    var unit = outage.UnitName || '';
-
-    var desc = label + ' outage at ' + station;
-    if (location) desc += ' — ' + location;
-    if (symptom) desc += ' (' + symptom + ')';
-    if (unit) desc += ' [Unit: ' + unit + ']';
-
-    return {
-      IncidentType: label,
-      Description: desc,
-      LinesAffected: '',
-      DateUpdated: outage.DateUpdated || outage.DateOutOfServ || '',
-      _station: station,
-      _unitType: unitType,
-    };
-  });
-}
-
 // ---- State ----
-var currentAlerts = []; // unified list: rail incidents + elevator/escalator
-var currentRailIncidents = []; // rail-only for ticker + status bar
+var currentAlerts = []; // rail incidents only
 var activeLineFilter = 'all'; // 'all' | line code
 var pollingInterval = null;
 
@@ -171,11 +140,8 @@ function renderStatusBar(incidents) {
 function getFilteredAlerts() {
   if (activeLineFilter === 'all') return currentAlerts;
   return currentAlerts.filter(function (incident) {
-    // Rail incidents — check LinesAffected
     var lines = parseAffectedLines(incident.LinesAffected);
     if (lines.length > 0) return lines.indexOf(activeLineFilter) !== -1;
-    // Elevator/escalator — check station code prefix
-    if (incident._station) return true; // Show facility alerts for all line filters
     return true;
   });
 }
@@ -192,14 +158,6 @@ function getAlertIcon(severityLabel) {
   }
   if (severityLabel === 'Alert') {
     return '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/></svg>';
-  }
-  if (severityLabel === 'Elevator') {
-    // Elevator icon
-    return '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"/></svg>';
-  }
-  if (severityLabel === 'Escalator') {
-    // Escalator/stairs icon
-    return '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14l-4-4 1.41-1.41L12 14.17l6.59-6.59L20 9l-8 8z"/></svg>';
   }
   // Advisory — info circle
   return '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>';
@@ -285,16 +243,6 @@ function renderAlerts() {
     var timeStr = formatAlertTime(incident.DateUpdated);
     var delay = Math.min(idx * 0.06, 0.6);
 
-    // Location tag for station-level alerts
-    var locationHtml = '';
-    if (incident._station) {
-      locationHtml =
-        '<span class="alert-station-pill">' +
-        '<svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5a2.5 2.5 0 010-5 2.5 2.5 0 010 5z"/></svg>' +
-        escapeHtml(incident._station) +
-        '</span>';
-    }
-
     // Line pills for this alert
     var linePillsHtml = '';
     affectedLines.forEach(function (lineCode) {
@@ -306,8 +254,8 @@ function renderAlerts() {
     });
 
     var tagsHtml = '';
-    if (linePillsHtml || locationHtml) {
-      tagsHtml = '<div class="alerts-card-tags">' + linePillsHtml + locationHtml + '</div>';
+    if (linePillsHtml) {
+      tagsHtml = '<div class="alerts-card-tags">' + linePillsHtml + '</div>';
     }
 
     html +=
@@ -341,14 +289,11 @@ function updateSEO(allAlerts) {
     desc = 'All DC Metro lines operating normally. No active service alerts. Live status updates at NextMetro.';
   } else {
     var lineSet = new Set();
-    var hasElevator = false;
     allAlerts.forEach(function (inc) {
       parseAffectedLines(inc.LinesAffected).forEach(function (code) { lineSet.add(lineNames[code]); });
-      if (inc.IncidentType === 'Elevator' || inc.IncidentType === 'Escalator') hasElevator = true;
     });
     var parts = [];
     if (lineSet.size > 0) parts.push(Array.from(lineSet).join(', '));
-    if (hasElevator) parts.push('elevator/escalator outages');
     desc = alertCount + ' active alert' + (alertCount !== 1 ? 's' : '') +
       (parts.length > 0 ? ' — ' + parts.join(', ') : '') +
       '. Live DC Metro status at NextMetro.';
@@ -364,12 +309,9 @@ function updateSEO(allAlerts) {
     lastUpdatedTime.textContent = now.toISOString();
   }
 
-  // SpecialAnnouncement schema for active alerts (rail incidents only)
-  var railAlerts = allAlerts.filter(function (a) {
-    return a.IncidentType !== 'Elevator' && a.IncidentType !== 'Escalator';
-  });
-  if (schemaAlerts && railAlerts.length > 0) {
-    var announcements = railAlerts.map(function (incident) {
+  // SpecialAnnouncement schema for active alerts
+  if (schemaAlerts && allAlerts.length > 0) {
+    var announcements = allAlerts.map(function (incident) {
       return {
         '@context': 'https://schema.org',
         '@type': 'SpecialAnnouncement',
@@ -408,43 +350,25 @@ function updateTimestamp() {
 }
 
 // ==============================
-// Fetch All Alerts (rail incidents + elevator/escalator)
+// Fetch Rail Alerts
 // ==============================
 async function fetchAllAlerts() {
   var railIncidents = [];
-  var elevatorIncidents = [];
 
-  // Fetch both endpoints in parallel
-  var results = await Promise.allSettled([
-    fetchWithRetry(API_BASE_URL + '/api/incidents'),
-    fetchWithRetry(API_BASE_URL + '/api/elevators'),
-  ]);
-
-  // Rail incidents
-  if (results[0].status === 'fulfilled' && results[0].value && results[0].value.ok) {
-    try {
-      var railData = await safeJson(results[0].value);
+  try {
+    var response = await fetchWithRetry(API_BASE_URL + '/api/incidents');
+    if (response && response.ok) {
+      var railData = await safeJson(response);
       railIncidents = deduplicateIncidents(railData.Incidents || []);
-    } catch (e) {
-      console.error('Failed to parse rail incidents:', e.message);
     }
+  } catch (e) {
+    console.error('Failed to fetch rail incidents:', e.message);
   }
 
-  // Elevator/escalator outages
-  if (results[1].status === 'fulfilled' && results[1].value && results[1].value.ok) {
-    try {
-      var elevData = await safeJson(results[1].value);
-      elevatorIncidents = normalizeElevatorIncidents(elevData.ElevatorIncidents || []);
-    } catch (e) {
-      console.error('Failed to parse elevator incidents:', e.message);
-    }
-  }
-
-  currentRailIncidents = railIncidents;
-  currentAlerts = railIncidents.concat(elevatorIncidents);
+  currentAlerts = railIncidents;
 
   renderAlerts();
-  renderStatusBar(currentRailIncidents);
+  renderStatusBar(currentAlerts);
   updateTimestamp();
   updateSEO(currentAlerts);
 }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -9,7 +9,7 @@
   </url>
   <url>
     <loc>https://nextmetro.live/alerts/</loc>
-    <lastmod>2026-03-22</lastmod>
+    <lastmod>2026-04-08</lastmod>
     <changefreq>always</changefreq>
     <priority>0.9</priority>
   </url>


### PR DESCRIPTION
## Summary
Refactored the alerts page to focus exclusively on rail service disruptions (delays, closures, advisories, single tracking). Elevator and escalator outages have been moved to a dedicated `/elevators/` page, simplifying the alerts page logic and improving separation of concerns.

## Key Changes

**JavaScript (`public/js/alerts.js`)**
- Removed elevator/escalator severity levels and icon rendering
- Deleted `normalizeElevatorIncidents()` function that transformed elevator data
- Removed dual API fetch for both rail incidents and elevator outages; now only fetches `/api/incidents`
- Simplified alert filtering logic (removed station-based filtering for facility alerts)
- Removed elevator/escalator-specific rendering (station pills, facility severity styling)
- Updated SEO metadata generation to exclude elevator/escalator references
- Removed `currentRailIncidents` variable; `currentAlerts` now contains rail incidents only

**CSS (`public/css/alerts-page.css`)**
- Removed `.severity-facility` styling for elevator/escalator alerts
- Removed `.alert-station-pill` styling (location tags)
- Restructured status bar layout with new `.alerts-status-wrap` wrapper for better spacing
- Updated responsive breakpoints for the new status bar positioning

**HTML (`public/alerts/index.html`)**
- Updated page title from "DC Metro Alerts & Outages" to "DC Metro Alerts"
- Updated meta descriptions to reference service advisories instead of elevator outages
- Moved status bar outside hero section into dedicated wrapper
- Updated FAQ section:
  - Changed "Why are there so many elevator outages?" to "Where can I find elevator and escalator outages?" with link to `/elevators/`
  - Updated polling frequency FAQ to mention only rail API
  - Updated Metrorail scope FAQ to clarify elevator/escalator are on separate page

## Implementation Details
- The alerts page now has a single, focused responsibility: displaying rail service disruptions
- Elevator/escalator data is no longer fetched or processed on this page
- Status bar positioning improved with dedicated wrapper for better layout control
- All references to facility-level alerts removed from filtering and rendering logic

https://claude.ai/code/session_013zmEccUapEfkNs7RJGNvxR