### PR TITLE
Update DC Metro fare terminology from peak/off-peak to weekday/late-night

### DIFF
--- a/public/css/fares.css
+++ b/public/css/fares.css
@@ -650,8 +650,68 @@
     min-width: auto;
   }
 
-  .fare-table thead th,
+  .fare-table-wrapper {
+    border: none;
+    overflow-x: visible;
+  }
+
+  .fare-table thead {
+    display: none;
+  }
+
+  .fare-table,
+  .fare-table tbody,
+  .fare-table tr,
+  .fare-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .fare-table tbody tr {
+    background-color: var(--nm-surface);
+    border: 1px solid var(--nm-border);
+    margin-bottom: var(--nm-space-sm);
+    padding: var(--nm-space-sm) 0;
+  }
+
+  .fare-table tbody tr:hover {
+    background-color: var(--nm-surface-elevated);
+  }
+
   .fare-table tbody td {
-    padding: 0.5rem 0.6rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 0.4rem 1rem;
+    border-bottom: none;
+    text-align: right;
+  }
+
+  .fare-table tbody td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    font-size: 0.8rem;
+    color: var(--nm-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    text-align: left;
+    flex-shrink: 0;
+    padding-right: var(--nm-space-sm);
+  }
+
+  .fare-table tbody td:first-child {
+    font-weight: 700;
+    color: var(--nm-text-primary);
+    border-bottom: 1px solid var(--nm-border-subtle);
+    padding-bottom: 0.5rem;
+    margin-bottom: 0.2rem;
+  }
+
+  .fare-table tbody td:first-child::before {
+    display: none;
+  }
+
+  .fare-table tbody td:first-child {
+    text-align: left;
   }
 }

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -74,15 +74,15 @@
         "name": "How much does the DC Metro cost?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "DC Metro fares range from $2.25 to $6.75 per trip depending on distance traveled and time of day. Weekday fares range from $2.25 to $6.75, while late night and weekend fares range from $2.25 to $2.50. Senior citizens and persons with disabilities pay approximately half the regular fare."
+          "text": "DC Metro fares are distance-based and range from $2.25 to $6.75 per trip on weekdays (opening through 9:30 PM). Late night (after 9:30 PM) and weekend fares range from $2.25 to $2.50. Senior citizens and persons with disabilities pay a reduced fare of $1.10 to $3.35."
         }
       },
       {
         "@type": "Question",
-        "name": "What are DC Metro peak hours?",
+        "name": "When do different DC Metro fare rates apply?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Weekday fares apply Monday through Friday from opening through 9:30 PM. Late night fares apply after 9:30 PM on weekdays. Weekend fares apply all day Saturday and Sunday. Federal holidays use weekend fare rates."
+          "text": "Weekday fares ($2.25–$6.75, distance-based) apply Monday through Friday from opening through 9:30 PM. Late night fares ($2.25–$2.50) apply after 9:30 PM on weekdays. Weekend and federal holiday fares are $2.25–$2.50 all day. There is no separate peak or rush-hour surcharge — all weekday rides before 9:30 PM use the same distance-based fare."
         }
       },
       {
@@ -166,7 +166,7 @@
       <span class="fares-hero-label">Fares</span>
       <h1 class="fares-hero-title">Fare Calculator</h1>
       <p class="fares-hero-subtitle">
-        Calculate the cost of your Metrorail trip. Metro fares range from $2.25 to $6.75 depending on distance traveled and time of day.
+        Calculate the cost of your Metrorail trip. Weekday fares range from $2.25 to $6.75 based on distance. Late night and weekend fares are $2.25 – $2.50.
       </p>
       <div class="peak-indicator" id="peak-indicator">
         <span class="peak-indicator-dot" id="peak-dot"></span>
@@ -227,14 +227,14 @@
         <div class="calc-results" id="calc-results" style="display:none;">
           <div class="calc-results-grid">
             <div class="calc-result-item">
-              <span class="calc-result-label">Peak Fare</span>
+              <span class="calc-result-label">Weekday Fare</span>
               <span class="calc-result-value calc-result-value--highlight" id="result-peak">--</span>
-              <span class="calc-result-note">Weekdays, rush hours</span>
+              <span class="calc-result-note">Mon–Fri, opening – 9:30 PM</span>
             </div>
             <div class="calc-result-item">
-              <span class="calc-result-label">Off-Peak Fare</span>
+              <span class="calc-result-label">Late Night / Weekend</span>
               <span class="calc-result-value calc-result-value--highlight" id="result-offpeak">--</span>
-              <span class="calc-result-note">Evenings, weekends, holidays</span>
+              <span class="calc-result-note">After 9:30 PM, weekends, holidays</span>
             </div>
             <div class="calc-result-item">
               <span class="calc-result-label">Travel Time</span>
@@ -291,34 +291,34 @@
           </thead>
           <tbody>
             <tr>
-              <td>Boarding (minimum fare)</td>
-              <td class="fare-price">$2.25</td>
-              <td class="fare-price">$2.25</td>
-              <td class="fare-price">$1.10</td>
+              <td data-label="Fare Category">Boarding (minimum fare)</td>
+              <td data-label="Weekday" class="fare-price">$2.25</td>
+              <td data-label="Late Night / Weekend" class="fare-price">$2.25</td>
+              <td data-label="Senior/Disabled" class="fare-price">$1.10</td>
             </tr>
             <tr>
-              <td>Short trip (1-3 miles)</td>
-              <td class="fare-price">$2.25 - $3.00</td>
-              <td class="fare-price">$2.25</td>
-              <td class="fare-price">$1.10</td>
+              <td data-label="Fare Category">Short trip (1–3 miles)</td>
+              <td data-label="Weekday" class="fare-price">$2.25 – $3.00</td>
+              <td data-label="Late Night / Weekend" class="fare-price">$2.25</td>
+              <td data-label="Senior/Disabled" class="fare-price">$1.10</td>
             </tr>
             <tr>
-              <td>Medium trip (3-6 miles)</td>
-              <td class="fare-price">$3.00 - $4.50</td>
-              <td class="fare-price">$2.25 - $2.50</td>
-              <td class="fare-price">$1.10 - $2.25</td>
+              <td data-label="Fare Category">Medium trip (3–6 miles)</td>
+              <td data-label="Weekday" class="fare-price">$3.00 – $4.50</td>
+              <td data-label="Late Night / Weekend" class="fare-price">$2.25 – $2.50</td>
+              <td data-label="Senior/Disabled" class="fare-price">$1.10 – $2.25</td>
             </tr>
             <tr>
-              <td>Long trip (6+ miles)</td>
-              <td class="fare-price">$4.50 - $6.75</td>
-              <td class="fare-price">$2.50</td>
-              <td class="fare-price">$2.25 - $3.35</td>
+              <td data-label="Fare Category">Long trip (6+ miles)</td>
+              <td data-label="Weekday" class="fare-price">$4.50 – $6.75</td>
+              <td data-label="Late Night / Weekend" class="fare-price">$2.50</td>
+              <td data-label="Senior/Disabled" class="fare-price">$2.25 – $3.35</td>
             </tr>
             <tr>
-              <td>Maximum fare</td>
-              <td class="fare-price">$6.75</td>
-              <td class="fare-price">$2.50</td>
-              <td class="fare-price">$3.35</td>
+              <td data-label="Fare Category">Maximum fare</td>
+              <td data-label="Weekday" class="fare-price">$6.75</td>
+              <td data-label="Late Night / Weekend" class="fare-price">$2.50</td>
+              <td data-label="Senior/Disabled" class="fare-price">$3.35</td>
             </tr>
           </tbody>
         </table>

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>DC Metro Fare Calculator: Peak &amp; Off-Peak Prices | NextMetro</title>
-  <meta name="description" content="Calculate DC Metro fares between any two stations. Compare peak, off-peak, weekend, and senior/disabled prices." />
+  <title>DC Metro Fare Calculator: Weekday &amp; Weekend Prices | NextMetro</title>
+  <meta name="description" content="Calculate DC Metro fares between any two stations. Compare weekday, late night, weekend, and senior/disabled prices." />
   <link rel="canonical" href="https://nextmetro.live/fares/" />
   <link rel="stylesheet" href="/css/styles.css" />
   <link rel="stylesheet" href="/css/fares.css" />
@@ -15,8 +15,8 @@
   <link href="https://cdn.jsdelivr.net/npm/remixicon@4.6.0/fonts/remixicon.css" rel="stylesheet" integrity="sha256-MblAFgCXnFAJlRJnqJqOjRfz0ODAP+6LxfGQEK7g1o=" crossorigin="anonymous" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="DC Metro Fare Calculator: Peak &amp; Off-Peak Prices | NextMetro" />
-  <meta property="og:description" content="Calculate DC Metro fares between any two stations. Compare peak, off-peak, and senior/disabled prices." />
+  <meta property="og:title" content="DC Metro Fare Calculator: Weekday &amp; Weekend Prices | NextMetro" />
+  <meta property="og:description" content="Calculate DC Metro fares between any two stations. Compare weekday, late night/weekend, and senior/disabled prices." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://nextmetro.live/fares/" />
   <meta property="og:site_name" content="NextMetro" />
@@ -28,8 +28,8 @@
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="DC Metro Fare Calculator: Peak &amp; Off-Peak Prices | NextMetro" />
-  <meta name="twitter:description" content="Calculate DC Metro fares between any two stations. Compare peak, off-peak, and senior/disabled prices." />
+  <meta name="twitter:title" content="DC Metro Fare Calculator: Weekday &amp; Weekend Prices | NextMetro" />
+  <meta name="twitter:description" content="Calculate DC Metro fares between any two stations. Compare weekday, late night/weekend, and senior/disabled prices." />
   <meta name="twitter:image" content="https://nextmetro.live/images/og/homepage-utility/og-fares.png" />
 
   <!-- Favicon -->
@@ -277,7 +277,7 @@
     <div class="fares-section animate-in d2">
       <h2 class="fares-section-heading">Fare Structure</h2>
       <p class="fares-text">
-        Metrorail uses a distance-based fare system. The further you travel, the more you pay. Fares also vary by time of day — <strong>peak fares</strong> apply during rush hours on weekdays, while <strong>off-peak fares</strong> apply at all other times.
+        Metrorail uses a distance-based fare system. The further you travel, the more you pay. <strong>Weekday fares</strong> (opening – 9:30 PM) are distance-based, while <strong>late night and weekend fares</strong> use a reduced flat rate. There is no separate rush-hour surcharge.
       </p>
       <div class="fare-table-wrapper">
         <table class="fare-table">

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -87,10 +87,18 @@
       },
       {
         "@type": "Question",
-        "name": "Do I need a SmarTrip card to ride Metro?",
+        "name": "How do I pay to ride DC Metro?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Yes, a SmarTrip card or contactless payment method is required to ride Metrorail. SmarTrip cards can be purchased at fare machines in any Metro station for $2.00. You can also use contactless credit/debit cards and mobile wallets (Apple Pay, Google Pay) at fare gates."
+          "text": "You can tap a contactless credit or debit card, Apple Pay, or Google Pay at the fare gates. You can also purchase a reloadable fare card for $2.00 at fare machines in every station. Passes and employer transit benefits can be loaded to your fare card account."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does Metro offer unlimited ride passes?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Metro offers 1-Day ($13.50), 3-Day ($33.75), and 7-Day ($60.75) unlimited passes covering Metrorail and Metrobus. A 7-Day Short-Trip pass ($40.50) covers rail trips up to $4.50. Monthly unlimited passes range from $72 to $216 based on your fare level."
         }
       },
       {
@@ -98,7 +106,7 @@
         "name": "How do Metro transfers work?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Rail-to-rail transfers within the Metrorail system are included in your fare — you can transfer between lines at no additional cost during a continuous trip. Rail-to-bus and bus-to-rail transfers are free ($2.25 discount) within a 2-hour window when using SmarTrip. Bus-to-bus transfers are also free with unlimited transfers within 2 hours."
+          "text": "Rail-to-rail transfers within the Metrorail system are included in your fare — you can transfer between lines at no additional cost during a continuous trip. Rail-to-bus and bus-to-rail transfers include a $2.25 discount within a 2-hour window. Bus-to-bus transfers are free with unlimited transfers within 2 hours."
         }
       }
     ]
@@ -358,29 +366,82 @@
       </p>
     </div>
 
-    <!-- Transfer Rules & SmarTrip -->
+    <!-- Passes -->
     <div class="fares-section animate-in d4">
-      <h2 class="fares-section-heading">Transfers & SmarTrip</h2>
+      <h2 class="fares-section-heading">Passes</h2>
+      <p class="fares-text">
+        Metro offers several pass options for frequent riders. Passes cover unlimited Metrorail and Metrobus rides for the duration of the pass.
+      </p>
+      <div class="fare-table-wrapper">
+        <table class="fare-table">
+          <thead>
+            <tr>
+              <th>Pass</th>
+              <th>Price</th>
+              <th>Details</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td data-label="Pass">1-Day Unlimited</td>
+              <td data-label="Price" class="fare-price">$13.50</td>
+              <td data-label="Details">Unlimited rail &amp; bus; expires end of operating day</td>
+            </tr>
+            <tr>
+              <td data-label="Pass">3-Day Unlimited</td>
+              <td data-label="Price" class="fare-price">$33.75</td>
+              <td data-label="Details">Unlimited rail &amp; bus; 3 consecutive operating days</td>
+            </tr>
+            <tr>
+              <td data-label="Pass">7-Day Unlimited</td>
+              <td data-label="Price" class="fare-price">$60.75</td>
+              <td data-label="Details">Unlimited rail &amp; bus; 7 consecutive operating days</td>
+            </tr>
+            <tr>
+              <td data-label="Pass">7-Day Short-Trip</td>
+              <td data-label="Price" class="fare-price">$40.50</td>
+              <td data-label="Details">Rail trips up to $4.50; excess deducted from stored value</td>
+            </tr>
+            <tr>
+              <td data-label="Pass">7-Day Regional Bus</td>
+              <td data-label="Price" class="fare-price">$13.50</td>
+              <td data-label="Details">Metrobus &amp; regional partners; $6.75 reduced fare</td>
+            </tr>
+            <tr>
+              <td data-label="Pass">Monthly Unlimited</td>
+              <td data-label="Price" class="fare-price">$72 – $216</td>
+              <td data-label="Details">Priced at 32&times; your fare level; includes unlimited bus</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="fares-text" style="margin-top:var(--nm-space-md)">
+        For full pass details, see <a href="https://www.wmata.com/fares/farecard-options.cfm" target="_blank" rel="noopener noreferrer">WMATA pass options</a>.
+      </p>
+    </div>
+
+    <!-- Transfers & How to Pay -->
+    <div class="fares-section animate-in d5">
+      <h2 class="fares-section-heading">Transfers &amp; How to Pay</h2>
       <div class="info-grid">
         <div class="info-card">
           <h3 class="info-card-title">Transfer Rules</h3>
           <ul class="info-card-list">
             <li>Rail-to-rail transfers are included in your fare during a continuous trip</li>
-            <li>Rail-to-bus and bus-to-rail transfers are free ($2.25 discount) within 2 hours with SmarTrip</li>
+            <li>Rail-to-bus and bus-to-rail transfers are free ($2.25 discount) within 2 hours</li>
             <li>Bus-to-bus transfers are free with unlimited transfers within 2 hours</li>
             <li>Transfers are valid for up to 2 hours from the start of your trip</li>
           </ul>
         </div>
         <div class="info-card">
-          <h3 class="info-card-title">SmarTrip Card</h3>
+          <h3 class="info-card-title">How to Pay</h3>
           <div class="info-card-text">
-            <p>A SmarTrip card or contactless payment is required to ride Metrorail. Cards cost <strong>$2.00</strong> and can be purchased at:</p>
+            <p>A fare card or contactless payment is required to ride Metrorail. Options include:</p>
             <ul class="info-card-list">
-              <li>Fare machines in every Metro station</li>
-              <li>Select retail locations</li>
-              <li><a href="https://www.wmata.com/fares/smartrip/" target="_blank" rel="noopener noreferrer">Online at wmata.com</a></li>
+              <li>Contactless credit/debit card or mobile wallet (Apple Pay, Google Pay) at fare gates</li>
+              <li><a href="https://www.wmata.com/fares/smartrip/" target="_blank" rel="noopener noreferrer">SmarTrip card</a> — $2.00 at fare machines in every station</li>
+              <li>Passes loaded to your account via <a href="https://www.wmata.com/fares/smartbenefits/" target="_blank" rel="noopener noreferrer">employer transit benefits</a></li>
             </ul>
-            <p class="info-card-text-note">You can also tap a contactless credit/debit card or mobile wallet (Apple Pay, Google Pay) at fare gates.</p>
           </div>
         </div>
       </div>

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -90,7 +90,7 @@
         "name": "How do I pay to ride DC Metro?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "You can tap a contactless credit or debit card, Apple Pay, or Google Pay at the fare gates. You can also use a SmarTrip card, available for $2.00 at fare machines in every station. Passes and employer transit benefits are loaded to your SmarTrip account."
+          "text": "You can tap a contactless credit or debit card, Apple Pay, or Google Pay at the fare gates. You can also use a SmarTrip® card, available for $2.00 at fare machines in every station. Passes and employer transit benefits are loaded to your SmarTrip account."
         }
       },
       {
@@ -416,7 +416,7 @@
         </table>
       </div>
       <p class="fares-text" style="margin-top:var(--nm-space-md)">
-        Passes require a <a href="https://www.wmata.com/fares/smartrip/" target="_blank" rel="noopener noreferrer">SmarTrip card</a> — they cannot be used with contactless tap-to-pay. For full pass details, see <a href="https://www.wmata.com/fares/farecard-options.cfm" target="_blank" rel="noopener noreferrer">WMATA pass options</a>.
+        Passes require a <a href="https://www.wmata.com/fares/smartrip/" target="_blank" rel="noopener noreferrer">SmarTrip&reg; card</a> — they cannot be used with contactless tap-to-pay. For full pass details, see <a href="https://www.wmata.com/fares/farecard-options.cfm" target="_blank" rel="noopener noreferrer">WMATA pass options</a>.
       </p>
     </div>
 

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -416,7 +416,7 @@
         </table>
       </div>
       <p class="fares-text" style="margin-top:var(--nm-space-md)">
-        For full pass details, see <a href="https://www.wmata.com/fares/farecard-options.cfm" target="_blank" rel="noopener noreferrer">WMATA pass options</a>.
+        Passes require a <a href="https://www.wmata.com/fares/smartrip/" target="_blank" rel="noopener noreferrer">SmarTrip card</a> — they cannot be used with contactless tap-to-pay. For full pass details, see <a href="https://www.wmata.com/fares/farecard-options.cfm" target="_blank" rel="noopener noreferrer">WMATA pass options</a>.
       </p>
     </div>
 

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -422,26 +422,22 @@
 
     <!-- Transfers & How to Pay -->
     <div class="fares-section animate-in d5">
-      <h2 class="fares-section-heading">Transfers &amp; How to Pay</h2>
+      <h2 class="fares-section-heading">Transfers &amp; SmarTrip</h2>
       <div class="info-grid">
         <div class="info-card">
           <h3 class="info-card-title">Transfer Rules</h3>
           <ul class="info-card-list">
             <li>Rail-to-rail transfers are included in your fare during a continuous trip</li>
-            <li>Rail-to-bus and bus-to-rail transfers are free ($2.25 discount) within 2 hours</li>
+            <li>Rail-to-bus and bus-to-rail transfers are free ($2.25 discount) within 2 hours with SmarTrip</li>
             <li>Bus-to-bus transfers are free with unlimited transfers within 2 hours</li>
             <li>Transfers are valid for up to 2 hours from the start of your trip</li>
           </ul>
         </div>
         <div class="info-card">
-          <h3 class="info-card-title">How to Pay</h3>
+          <h3 class="info-card-title">SmarTrip &amp; How to Pay</h3>
           <div class="info-card-text">
-            <p>A fare card or contactless payment is required to ride Metrorail. Options include:</p>
-            <ul class="info-card-list">
-              <li>Contactless credit/debit card or mobile wallet (Apple Pay, Google Pay) at fare gates</li>
-              <li><a href="https://www.wmata.com/fares/smartrip/" target="_blank" rel="noopener noreferrer">SmarTrip card</a> — $2.00 at fare machines in every station</li>
-              <li>Passes loaded to your account via <a href="https://www.wmata.com/fares/smartbenefits/" target="_blank" rel="noopener noreferrer">employer transit benefits</a></li>
-            </ul>
+            <p>A <a href="https://www.wmata.com/fares/smartrip/" target="_blank" rel="noopener noreferrer">SmarTrip card</a> or contactless payment is required to ride Metrorail. Cards cost <strong>$2.00</strong> and are available at fare machines in every station.</p>
+            <p class="info-card-text-note">You can also tap a contactless credit/debit card or mobile wallet (Apple Pay, Google Pay) at fare gates.</p>
           </div>
         </div>
       </div>

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -90,7 +90,7 @@
         "name": "How do I pay to ride DC Metro?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "You can tap a contactless credit or debit card, Apple Pay, or Google Pay at the fare gates. You can also purchase a reloadable fare card for $2.00 at fare machines in every station. Passes and employer transit benefits can be loaded to your fare card account."
+          "text": "You can tap a contactless credit or debit card, Apple Pay, or Google Pay at the fare gates. You can also use a SmarTrip card, available for $2.00 at fare machines in every station. Passes and employer transit benefits are loaded to your SmarTrip account."
         }
       },
       {

--- a/public/fares/index.html
+++ b/public/fares/index.html
@@ -74,7 +74,7 @@
         "name": "How much does the DC Metro cost?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "DC Metro fares are distance-based and range from $2.25 to $6.75 per trip on weekdays (opening through 9:30 PM). Late night (after 9:30 PM) and weekend fares range from $2.25 to $2.50. Senior citizens and persons with disabilities pay a reduced fare of $1.10 to $3.35."
+          "text": "DC Metro fares are distance-based and range from $2.25 to $6.75 per trip on weekdays (opening through 9:30 PM). Late night (after 9:30 PM) and weekend fares range from $2.25 to $2.50. Seniors, persons with disabilities, and Metro Lift (SNAP) participants pay a reduced fare of 50% off regular fares."
         }
       },
       {
@@ -219,7 +219,7 @@
         <div class="calc-options">
           <div class="calc-toggle" role="radiogroup" aria-label="Fare type">
             <button class="calc-toggle-btn calc-toggle-btn--active" data-fare-type="regular" role="radio" aria-checked="true">Regular</button>
-            <button class="calc-toggle-btn" data-fare-type="senior" role="radio" aria-checked="false">Senior/Disabled</button>
+            <button class="calc-toggle-btn" data-fare-type="senior" role="radio" aria-checked="false">Senior/Disabled &amp; Metro Lift</button>
           </div>
         </div>
 
@@ -286,7 +286,7 @@
               <th>Fare Category</th>
               <th>Weekday</th>
               <th>Late Night / Weekend</th>
-              <th>Senior/Disabled</th>
+              <th>Senior/Disabled &amp; Metro Lift</th>
             </tr>
           </thead>
           <tbody>
@@ -294,31 +294,31 @@
               <td data-label="Fare Category">Boarding (minimum fare)</td>
               <td data-label="Weekday" class="fare-price">$2.25</td>
               <td data-label="Late Night / Weekend" class="fare-price">$2.25</td>
-              <td data-label="Senior/Disabled" class="fare-price">$1.10</td>
+              <td data-label="Senior/Disabled &amp; Metro Lift" class="fare-price">$1.10</td>
             </tr>
             <tr>
               <td data-label="Fare Category">Short trip (1–3 miles)</td>
               <td data-label="Weekday" class="fare-price">$2.25 – $3.00</td>
               <td data-label="Late Night / Weekend" class="fare-price">$2.25</td>
-              <td data-label="Senior/Disabled" class="fare-price">$1.10</td>
+              <td data-label="Senior/Disabled &amp; Metro Lift" class="fare-price">$1.10 – $1.50</td>
             </tr>
             <tr>
               <td data-label="Fare Category">Medium trip (3–6 miles)</td>
               <td data-label="Weekday" class="fare-price">$3.00 – $4.50</td>
               <td data-label="Late Night / Weekend" class="fare-price">$2.25 – $2.50</td>
-              <td data-label="Senior/Disabled" class="fare-price">$1.10 – $2.25</td>
+              <td data-label="Senior/Disabled &amp; Metro Lift" class="fare-price">$1.50 – $2.25</td>
             </tr>
             <tr>
               <td data-label="Fare Category">Long trip (6+ miles)</td>
               <td data-label="Weekday" class="fare-price">$4.50 – $6.75</td>
               <td data-label="Late Night / Weekend" class="fare-price">$2.50</td>
-              <td data-label="Senior/Disabled" class="fare-price">$2.25 – $3.35</td>
+              <td data-label="Senior/Disabled &amp; Metro Lift" class="fare-price">$2.25 – $3.35</td>
             </tr>
             <tr>
               <td data-label="Fare Category">Maximum fare</td>
               <td data-label="Weekday" class="fare-price">$6.75</td>
               <td data-label="Late Night / Weekend" class="fare-price">$2.50</td>
-              <td data-label="Senior/Disabled" class="fare-price">$3.35</td>
+              <td data-label="Senior/Disabled &amp; Metro Lift" class="fare-price">$3.35</td>
             </tr>
           </tbody>
         </table>

--- a/public/hours/index.html
+++ b/public/hours/index.html
@@ -91,7 +91,7 @@
         "name": "What are Metro peak hours?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "WMATA eliminated traditional peak/off-peak fare pricing in 2024. Weekday fares before 9:30 PM are distance-based ($2.25-$6.75). After 9:30 PM and on weekends, a flat fare applies ($2.25-$2.50)."
+          "text": "WMATA eliminated traditional peak/off-peak fare pricing in June 2023. All weekday rides before 9:30 PM now use one distance-based fare ($2.25-$6.75). After 9:30 PM and on weekends/holidays, a reduced fare applies ($2.25-$2.50)."
         }
       },
       {
@@ -107,7 +107,7 @@
         "name": "Does Metro run on holidays?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Yes, Metro runs on federal holidays using weekend hours (6 AM - midnight). Off-peak fares apply all day, and parking is free at Metro-owned lots."
+          "text": "Yes, Metro runs on federal holidays using weekend hours (6 AM - midnight). Weekend/holiday fares ($2.25-$2.50) apply all day, and parking is free at Metro-owned lots."
         }
       }
     ]
@@ -403,7 +403,7 @@
         <a href="/fares/">Calculate your fare &rarr;</a>
       </p>
       <p class="hours-text hours-text--note">
-        <strong>Note:</strong> WMATA eliminated traditional "peak" and "off-peak" pricing in June 2024. If you see references to "peak hours" affecting fares on other sites, that information is outdated.
+        <strong>Note:</strong> WMATA eliminated traditional "peak" and "off-peak" fare pricing in June 2023. All weekday rides before 9:30 PM now use the same distance-based fare. If you see references to "peak hours" affecting fares on other sites, that information is outdated.
       </p>
     </div>
 
@@ -813,7 +813,7 @@
       <div class="hours-tip-card">
         <h3 class="hours-tip-card-title">On holidays</h3>
         <ul class="hours-tip-list">
-          <li><strong>Off-peak fares apply all day</strong> (flat rate, not distance-based)</li>
+          <li><strong>Weekend/holiday fares apply all day</strong> ($2.25–$2.50 flat rate)</li>
           <li><strong>Parking is free</strong> at Metro-owned garages and lots</li>
           <li>Weekend frequency means trains arrive every 6–15 minutes depending on line</li>
         </ul>
@@ -993,7 +993,7 @@
         <details class="line-faq-item">
           <summary class="line-faq-question">Does Metro run on holidays?</summary>
           <div class="line-faq-answer">
-            <p>Yes, Metro operates on all federal holidays, typically using weekend hours and frequency (6 AM – midnight, trains every 6–15 minutes). Off-peak fares apply all day on holidays, and parking is free at Metro-owned garages and lots. Some holidays like July 4th and New Year's Eve may have extended hours announced closer to the date.</p>
+            <p>Yes, Metro operates on all federal holidays, typically using weekend hours and frequency (6 AM – midnight, trains every 6–15 minutes). Weekend/holiday fares ($2.25–$2.50) apply all day, and parking is free at Metro-owned garages and lots. Some holidays like July 4th and New Year's Eve may have extended hours announced closer to the date.</p>
           </div>
         </details>
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -650,8 +650,16 @@ fareDestination.addEventListener('change', async () => {
     farePeak.textContent = fare.PeakTime != null ? '$' + fare.PeakTime.toFixed(2) : '--';
     fareOffpeak.textContent =
       fare.OffPeakTime != null ? '$' + fare.OffPeakTime.toFixed(2) : '--';
-    fareSenior.textContent =
-      fare.SeniorDisabled != null ? '$' + fare.SeniorDisabled.toFixed(2) : '--';
+    // Compute reduced fare client-side (WMATA API SeniorDisabled field is stale)
+    if (fare.PeakTime != null) {
+      var cents = Math.round(fare.PeakTime * 100);
+      var halfCents = Math.floor(cents / 2);
+      var rounded = Math.floor(halfCents / 5) * 5;
+      var reduced = Math.max(1.10, rounded / 100);
+      fareSenior.textContent = '$' + reduced.toFixed(2);
+    } else {
+      fareSenior.textContent = '--';
+    }
     fareTime.textContent =
       info.RailTime != null ? info.RailTime + ' min' : '--';
 

--- a/public/js/fares.js
+++ b/public/js/fares.js
@@ -29,9 +29,12 @@ const peakText = document.getElementById('peak-text');
 const peakTimeEl = document.getElementById('peak-time');
 
 // ==============================
-// Peak Time Detection
+// Weekday / Late-Night-Weekend Fare Detection
+// WMATA eliminated peak/off-peak within weekdays in June 2023.
+// The fare distinction is now: weekday (opening–9:30 PM) vs.
+// late night (after 9:30 PM) / weekends / federal holidays.
 // ==============================
-function isPeakTime(date) {
+function isWeekdayFare(date) {
   const day = date.getDay(); // 0 = Sunday, 6 = Saturday
   if (day === 0 || day === 6) return false; // weekends
 
@@ -39,28 +42,32 @@ function isPeakTime(date) {
   const minutes = date.getMinutes();
   const timeInMinutes = hours * 60 + minutes;
 
-  // Morning peak: opening (~5:00 AM) to 9:30 AM
-  const morningStart = 5 * 60;   // 5:00 AM
-  const morningEnd = 9 * 60 + 30; // 9:30 AM
+  // Weekday fares apply from opening (~5:00 AM) until 9:30 PM
+  const openingTime = 5 * 60;       // 5:00 AM
+  const lateNightStart = 21 * 60 + 30; // 9:30 PM
 
-  // Evening peak: 3:00 PM to 7:00 PM
-  const eveningStart = 15 * 60;   // 3:00 PM
-  const eveningEnd = 19 * 60;     // 7:00 PM
-
-  return (timeInMinutes >= morningStart && timeInMinutes < morningEnd) ||
-         (timeInMinutes >= eveningStart && timeInMinutes < eveningEnd);
+  return timeInMinutes >= openingTime && timeInMinutes < lateNightStart;
 }
+
+// Keep isPeakTime as an alias — the WMATA API still returns
+// PeakTime / OffPeakTime fields used by the calculator.
+const isPeakTime = isWeekdayFare;
 
 function updatePeakIndicator() {
   const now = new Date();
-  const peak = isPeakTime(now);
+  const weekday = isWeekdayFare(now);
+  const day = now.getDay();
+  const isWeekend = day === 0 || day === 6;
 
-  if (peak) {
+  if (weekday) {
     peakDot.className = 'peak-indicator-dot peak-indicator-dot--peak';
-    peakText.textContent = 'Peak Fares Active';
+    peakText.textContent = 'Weekday Fares Active';
+  } else if (isWeekend) {
+    peakDot.className = 'peak-indicator-dot peak-indicator-dot--offpeak';
+    peakText.textContent = 'Weekend Fares Active';
   } else {
     peakDot.className = 'peak-indicator-dot peak-indicator-dot--offpeak';
-    peakText.textContent = 'Off-Peak Fares Active';
+    peakText.textContent = 'Late Night Fares Active';
   }
 
   peakTimeEl.textContent = now.toLocaleTimeString([], {
@@ -176,15 +183,15 @@ function displayResults() {
   } else {
     resultPeak.textContent = '$' + d.peak.toFixed(2);
     resultOffpeak.textContent = '$' + d.offpeak.toFixed(2);
-    // Round trip: assume one peak, one off-peak leg for weekday commute
+    // Round trip estimate based on current fare window
     if (peak) {
-      const rt = d.peak + d.offpeak;
+      const rt = d.peak * 2;
       resultRoundtrip.textContent = '$' + rt.toFixed(2);
-      resultRoundtripNote.textContent = 'Peak + off-peak estimate';
+      resultRoundtripNote.textContent = 'Weekday round trip';
     } else {
       const rt = d.offpeak * 2;
       resultRoundtrip.textContent = '$' + rt.toFixed(2);
-      resultRoundtripNote.textContent = 'Off-peak both ways';
+      resultRoundtripNote.textContent = 'Late night / weekend round trip';
     }
   }
 

--- a/public/js/fares.js
+++ b/public/js/fares.js
@@ -78,6 +78,19 @@ function updatePeakIndicator() {
 }
 
 // ==============================
+// Reduced Fare Calculation
+// WMATA API SeniorDisabled field is stale for routes over ~4.5 miles.
+// Compute client-side as 50% of regular fare, rounded to nearest $0.05,
+// with a $1.10 floor — matches WMATA's published reduced fare policy.
+// ==============================
+function reducedFare(amount) {
+  var cents = Math.round(amount * 100);
+  var halfCents = Math.floor(cents / 2);
+  var rounded = Math.floor(halfCents / 5) * 5; // floor to nearest 5¢
+  return Math.max(1.10, rounded / 100);
+}
+
+// ==============================
 // Populate Station Selectors
 // ==============================
 function populateStations() {
@@ -126,7 +139,7 @@ async function fetchFare() {
     resultTime.textContent = '0 min';
     resultRoundtrip.textContent = '$0.00';
     resultRoundtripNote.textContent = '';
-    currentFareData = { peak: 0, offpeak: 0, senior: 0, time: 0 };
+    currentFareData = { peak: 0, offpeak: 0, seniorPeak: 0, seniorOffpeak: 0, time: 0 };
     calcResults.style.display = '';
     updateEstimator();
     return;
@@ -147,10 +160,13 @@ async function fetchFare() {
     }
 
     const fare = info.RailFare || {};
+    const peakAmt = fare.PeakTime || 0;
+    const offpeakAmt = fare.OffPeakTime || 0;
     currentFareData = {
-      peak: fare.PeakTime || 0,
-      offpeak: fare.OffPeakTime || 0,
-      senior: fare.SeniorDisabled || 0,
+      peak: peakAmt,
+      offpeak: offpeakAmt,
+      seniorPeak: reducedFare(peakAmt),
+      seniorOffpeak: reducedFare(offpeakAmt),
       time: info.RailTime || 0,
     };
 
@@ -175,11 +191,17 @@ function displayResults() {
   const peak = isPeakTime(new Date());
 
   if (fareType === 'senior') {
-    resultPeak.textContent = '$' + d.senior.toFixed(2);
-    resultOffpeak.textContent = '$' + d.senior.toFixed(2);
-    const rt = d.senior * 2;
-    resultRoundtrip.textContent = '$' + rt.toFixed(2);
-    resultRoundtripNote.textContent = 'Senior/Disabled flat rate';
+    resultPeak.textContent = '$' + d.seniorPeak.toFixed(2);
+    resultOffpeak.textContent = '$' + d.seniorOffpeak.toFixed(2);
+    if (peak) {
+      const rt = d.seniorPeak * 2;
+      resultRoundtrip.textContent = '$' + rt.toFixed(2);
+      resultRoundtripNote.textContent = 'Reduced weekday round trip';
+    } else {
+      const rt = d.seniorOffpeak * 2;
+      resultRoundtrip.textContent = '$' + rt.toFixed(2);
+      resultRoundtripNote.textContent = 'Reduced late night / weekend';
+    }
   } else {
     resultPeak.textContent = '$' + d.peak.toFixed(2);
     resultOffpeak.textContent = '$' + d.offpeak.toFixed(2);
@@ -222,7 +244,7 @@ function updateEstimator() {
   let costPerTrip;
 
   if (fareType === 'senior') {
-    costPerTrip = d.senior;
+    costPerTrip = d.seniorPeak * 0.6 + d.seniorOffpeak * 0.4;
   } else {
     // Assume a mix: roughly 60% peak, 40% off-peak for commuters
     costPerTrip = d.peak * 0.6 + d.offpeak * 0.4;

--- a/public/lines/blue/index.html
+++ b/public/lines/blue/index.html
@@ -159,7 +159,7 @@
 							"name": "How much does the Blue Line cost to ride?",
 							"acceptedAnswer": {
 								"@type": "Answer",
-								"text": "Blue Line fares range from $2.25 to $6.75 per trip depending on distance and time of day. Weekday fares (opening–9:30 PM) range from $2.25 to $6.75. Late night and weekend fares range from $2.25 to $2.50. A SmarTrip card or contactless payment is required."
+								"text": "Blue Line fares range from $2.25 to $6.75 per trip depending on distance and time of day. Weekday fares (opening–9:30 PM) range from $2.25 to $6.75. Late night and weekend fares range from $2.25 to $2.50. A SmarTrip® card or contactless payment is required."
 							}
 						},
 						{

--- a/public/lines/green/index.html
+++ b/public/lines/green/index.html
@@ -149,7 +149,7 @@
           "name": "How much does the Green Line cost to ride?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Green Line fares range from $2.25 to $6.75 per trip depending on distance and time of day. Weekday fares (opening–9:30 PM) range from $2.25 to $6.75. Late night and weekend fares range from $2.25 to $2.50. A SmarTrip card or contactless payment is required."
+            "text": "Green Line fares range from $2.25 to $6.75 per trip depending on distance and time of day. Weekday fares (opening–9:30 PM) range from $2.25 to $6.75. Late night and weekend fares range from $2.25 to $2.50. A SmarTrip® card or contactless payment is required."
           }
         },
         {

--- a/public/lines/orange/index.html
+++ b/public/lines/orange/index.html
@@ -149,7 +149,7 @@
           "name": "How much does the Orange Line cost to ride?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Orange Line fares range from $2.25 to $6.75 per trip depending on distance and time of day. Weekday fares (opening–9:30 PM) range from $2.25 to $6.75. Late night and weekend fares range from $2.25 to $2.50. A SmarTrip card or contactless payment is required."
+            "text": "Orange Line fares range from $2.25 to $6.75 per trip depending on distance and time of day. Weekday fares (opening–9:30 PM) range from $2.25 to $6.75. Late night and weekend fares range from $2.25 to $2.50. A SmarTrip® card or contactless payment is required."
           }
         },
         {

--- a/public/lines/red/index.html
+++ b/public/lines/red/index.html
@@ -149,7 +149,7 @@
           "name": "How much does the Red Line cost to ride?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Red Line fares range from $2.25 to $6.75 per trip depending on distance and time of day. Weekday fares (opening–9:30 PM) range from $2.25 to $6.75. Late night and weekend fares range from $2.25 to $2.50. A SmarTrip card or contactless payment is required."
+            "text": "Red Line fares range from $2.25 to $6.75 per trip depending on distance and time of day. Weekday fares (opening–9:30 PM) range from $2.25 to $6.75. Late night and weekend fares range from $2.25 to $2.50. A SmarTrip® card or contactless payment is required."
           }
         },
         {

--- a/public/lines/silver/index.html
+++ b/public/lines/silver/index.html
@@ -149,7 +149,7 @@
           "name": "How much does the Silver Line cost to ride?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Silver Line fares range from $2.25 to $6.75 per trip depending on distance and time of day. Weekday fares (opening–9:30 PM) range from $2.25 to $6.75. Late night and weekend fares range from $2.25 to $2.50. A SmarTrip card or contactless payment is required."
+            "text": "Silver Line fares range from $2.25 to $6.75 per trip depending on distance and time of day. Weekday fares (opening–9:30 PM) range from $2.25 to $6.75. Late night and weekend fares range from $2.25 to $2.50. A SmarTrip® card or contactless payment is required."
           }
         },
         {

--- a/public/lines/yellow/index.html
+++ b/public/lines/yellow/index.html
@@ -149,7 +149,7 @@
           "name": "How much does the Yellow Line cost to ride?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Yellow Line fares range from $2.25 to $6.75 per trip depending on distance and time of day. Weekday fares (opening–9:30 PM) range from $2.25 to $6.75. Late night and weekend fares range from $2.25 to $2.50. A SmarTrip card or contactless payment is required."
+            "text": "Yellow Line fares range from $2.25 to $6.75 per trip depending on distance and time of day. Weekday fares (opening–9:30 PM) range from $2.25 to $6.75. Late night and weekend fares range from $2.25 to $2.50. A SmarTrip® card or contactless payment is required."
           }
         },
         {

--- a/public/station/addison-road/index.html
+++ b/public/station/addison-road/index.html
@@ -298,7 +298,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -315,8 +315,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/addison-road/index.html
+++ b/public/station/addison-road/index.html
@@ -317,7 +317,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/anacostia/index.html
+++ b/public/station/anacostia/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/anacostia/index.html
+++ b/public/station/anacostia/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/archives/index.html
+++ b/public/station/archives/index.html
@@ -276,7 +276,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -291,8 +291,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/archives/index.html
+++ b/public/station/archives/index.html
@@ -293,7 +293,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/arlington-cemetery/index.html
+++ b/public/station/arlington-cemetery/index.html
@@ -275,7 +275,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -290,8 +290,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/arlington-cemetery/index.html
+++ b/public/station/arlington-cemetery/index.html
@@ -292,7 +292,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/ashburn/index.html
+++ b/public/station/ashburn/index.html
@@ -325,7 +325,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/ashburn/index.html
+++ b/public/station/ashburn/index.html
@@ -306,7 +306,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -323,8 +323,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/ballston/index.html
+++ b/public/station/ballston/index.html
@@ -268,7 +268,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -283,8 +283,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/ballston/index.html
+++ b/public/station/ballston/index.html
@@ -285,7 +285,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/benning-road/index.html
+++ b/public/station/benning-road/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/benning-road/index.html
+++ b/public/station/benning-road/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/bethesda/index.html
+++ b/public/station/bethesda/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/bethesda/index.html
+++ b/public/station/bethesda/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/braddock-road/index.html
+++ b/public/station/braddock-road/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/braddock-road/index.html
+++ b/public/station/braddock-road/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/branch-ave/index.html
+++ b/public/station/branch-ave/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/branch-ave/index.html
+++ b/public/station/branch-ave/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/brookland-cua/index.html
+++ b/public/station/brookland-cua/index.html
@@ -342,7 +342,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -361,11 +361,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/brookland-cua/index.html
+++ b/public/station/brookland-cua/index.html
@@ -369,7 +369,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/capitol-heights/index.html
+++ b/public/station/capitol-heights/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/capitol-heights/index.html
+++ b/public/station/capitol-heights/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/capitol-south/index.html
+++ b/public/station/capitol-south/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/capitol-south/index.html
+++ b/public/station/capitol-south/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/cheverly/index.html
+++ b/public/station/cheverly/index.html
@@ -298,7 +298,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -315,8 +315,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/cheverly/index.html
+++ b/public/station/cheverly/index.html
@@ -317,7 +317,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/clarendon/index.html
+++ b/public/station/clarendon/index.html
@@ -268,7 +268,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -283,8 +283,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/clarendon/index.html
+++ b/public/station/clarendon/index.html
@@ -285,7 +285,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/cleveland-park/index.html
+++ b/public/station/cleveland-park/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/cleveland-park/index.html
+++ b/public/station/cleveland-park/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/college-park/index.html
+++ b/public/station/college-park/index.html
@@ -342,7 +342,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -360,11 +360,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/college-park/index.html
+++ b/public/station/college-park/index.html
@@ -368,7 +368,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/columbia-heights/index.html
+++ b/public/station/columbia-heights/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/columbia-heights/index.html
+++ b/public/station/columbia-heights/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/congress-heights/index.html
+++ b/public/station/congress-heights/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/congress-heights/index.html
+++ b/public/station/congress-heights/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/court-house/index.html
+++ b/public/station/court-house/index.html
@@ -271,7 +271,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -286,8 +286,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/court-house/index.html
+++ b/public/station/court-house/index.html
@@ -288,7 +288,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/crystal-city/index.html
+++ b/public/station/crystal-city/index.html
@@ -275,7 +275,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -290,8 +290,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/crystal-city/index.html
+++ b/public/station/crystal-city/index.html
@@ -292,7 +292,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/dca-national-airport/index.html
+++ b/public/station/dca-national-airport/index.html
@@ -276,7 +276,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -291,8 +291,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/dca-national-airport/index.html
+++ b/public/station/dca-national-airport/index.html
@@ -293,7 +293,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/deanwood/index.html
+++ b/public/station/deanwood/index.html
@@ -298,7 +298,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -315,8 +315,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/deanwood/index.html
+++ b/public/station/deanwood/index.html
@@ -317,7 +317,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/downtown-largo/index.html
+++ b/public/station/downtown-largo/index.html
@@ -298,7 +298,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -315,8 +315,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/downtown-largo/index.html
+++ b/public/station/downtown-largo/index.html
@@ -317,7 +317,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/dunn-loring/index.html
+++ b/public/station/dunn-loring/index.html
@@ -286,7 +286,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/dunn-loring/index.html
+++ b/public/station/dunn-loring/index.html
@@ -269,7 +269,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -284,8 +284,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/dupont-circle/index.html
+++ b/public/station/dupont-circle/index.html
@@ -341,7 +341,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -360,11 +360,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/dupont-circle/index.html
+++ b/public/station/dupont-circle/index.html
@@ -368,7 +368,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/east-falls-church/index.html
+++ b/public/station/east-falls-church/index.html
@@ -286,7 +286,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/east-falls-church/index.html
+++ b/public/station/east-falls-church/index.html
@@ -269,7 +269,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -284,8 +284,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/eastern-market/index.html
+++ b/public/station/eastern-market/index.html
@@ -290,7 +290,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/eastern-market/index.html
+++ b/public/station/eastern-market/index.html
@@ -273,7 +273,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -288,8 +288,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/eisenhower-ave/index.html
+++ b/public/station/eisenhower-ave/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/eisenhower-ave/index.html
+++ b/public/station/eisenhower-ave/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/farragut-north/index.html
+++ b/public/station/farragut-north/index.html
@@ -276,7 +276,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -291,8 +291,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/farragut-north/index.html
+++ b/public/station/farragut-north/index.html
@@ -293,7 +293,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/farragut-west/index.html
+++ b/public/station/farragut-west/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/farragut-west/index.html
+++ b/public/station/farragut-west/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/federal-center-sw/index.html
+++ b/public/station/federal-center-sw/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/federal-center-sw/index.html
+++ b/public/station/federal-center-sw/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/federal-triangle/index.html
+++ b/public/station/federal-triangle/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/federal-triangle/index.html
+++ b/public/station/federal-triangle/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/foggy-bottom/index.html
+++ b/public/station/foggy-bottom/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/foggy-bottom/index.html
+++ b/public/station/foggy-bottom/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/forest-glen/index.html
+++ b/public/station/forest-glen/index.html
@@ -371,7 +371,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/forest-glen/index.html
+++ b/public/station/forest-glen/index.html
@@ -345,7 +345,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -363,11 +363,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/fort-totten/index.html
+++ b/public/station/fort-totten/index.html
@@ -396,7 +396,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/fort-totten/index.html
+++ b/public/station/fort-totten/index.html
@@ -369,7 +369,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -388,11 +388,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/franconia-springfield/index.html
+++ b/public/station/franconia-springfield/index.html
@@ -275,7 +275,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -290,8 +290,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/franconia-springfield/index.html
+++ b/public/station/franconia-springfield/index.html
@@ -292,7 +292,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/friendship-heights/index.html
+++ b/public/station/friendship-heights/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/friendship-heights/index.html
+++ b/public/station/friendship-heights/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/gallery-place/index.html
+++ b/public/station/gallery-place/index.html
@@ -332,7 +332,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/gallery-place/index.html
+++ b/public/station/gallery-place/index.html
@@ -315,7 +315,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -330,8 +330,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/georgia-ave-petworth/index.html
+++ b/public/station/georgia-ave-petworth/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/georgia-ave-petworth/index.html
+++ b/public/station/georgia-ave-petworth/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/glenmont/index.html
+++ b/public/station/glenmont/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/glenmont/index.html
+++ b/public/station/glenmont/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/greenbelt/index.html
+++ b/public/station/greenbelt/index.html
@@ -342,7 +342,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -360,11 +360,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/greenbelt/index.html
+++ b/public/station/greenbelt/index.html
@@ -368,7 +368,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/greensboro/index.html
+++ b/public/station/greensboro/index.html
@@ -252,7 +252,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -265,8 +265,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/greensboro/index.html
+++ b/public/station/greensboro/index.html
@@ -267,7 +267,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/grosvenor-strathmore/index.html
+++ b/public/station/grosvenor-strathmore/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/grosvenor-strathmore/index.html
+++ b/public/station/grosvenor-strathmore/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/herndon/index.html
+++ b/public/station/herndon/index.html
@@ -347,7 +347,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -366,11 +366,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/herndon/index.html
+++ b/public/station/herndon/index.html
@@ -374,7 +374,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/huntington/index.html
+++ b/public/station/huntington/index.html
@@ -266,7 +266,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -281,8 +281,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/huntington/index.html
+++ b/public/station/huntington/index.html
@@ -283,7 +283,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/hyattsville-crossing/index.html
+++ b/public/station/hyattsville-crossing/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/hyattsville-crossing/index.html
+++ b/public/station/hyattsville-crossing/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/innovation-center/index.html
+++ b/public/station/innovation-center/index.html
@@ -347,7 +347,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -366,11 +366,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/innovation-center/index.html
+++ b/public/station/innovation-center/index.html
@@ -374,7 +374,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/judiciary-square/index.html
+++ b/public/station/judiciary-square/index.html
@@ -275,7 +275,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -290,8 +290,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/judiciary-square/index.html
+++ b/public/station/judiciary-square/index.html
@@ -292,7 +292,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/king-street/index.html
+++ b/public/station/king-street/index.html
@@ -275,7 +275,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -290,8 +290,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/king-street/index.html
+++ b/public/station/king-street/index.html
@@ -292,7 +292,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/landover/index.html
+++ b/public/station/landover/index.html
@@ -298,7 +298,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -315,8 +315,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/landover/index.html
+++ b/public/station/landover/index.html
@@ -317,7 +317,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/lenfant-plaza/index.html
+++ b/public/station/lenfant-plaza/index.html
@@ -331,7 +331,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/lenfant-plaza/index.html
+++ b/public/station/lenfant-plaza/index.html
@@ -314,7 +314,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -329,8 +329,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/loudoun-gateway/index.html
+++ b/public/station/loudoun-gateway/index.html
@@ -347,7 +347,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -366,11 +366,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/loudoun-gateway/index.html
+++ b/public/station/loudoun-gateway/index.html
@@ -374,7 +374,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/mclean/index.html
+++ b/public/station/mclean/index.html
@@ -268,7 +268,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -283,8 +283,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/mclean/index.html
+++ b/public/station/mclean/index.html
@@ -285,7 +285,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/mcpherson-square/index.html
+++ b/public/station/mcpherson-square/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/mcpherson-square/index.html
+++ b/public/station/mcpherson-square/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/medical-center/index.html
+++ b/public/station/medical-center/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/medical-center/index.html
+++ b/public/station/medical-center/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/metro-center/index.html
+++ b/public/station/metro-center/index.html
@@ -415,7 +415,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/metro-center/index.html
+++ b/public/station/metro-center/index.html
@@ -388,7 +388,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -407,11 +407,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/minnesota-ave/index.html
+++ b/public/station/minnesota-ave/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/minnesota-ave/index.html
+++ b/public/station/minnesota-ave/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/morgan-boulevard/index.html
+++ b/public/station/morgan-boulevard/index.html
@@ -298,7 +298,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -315,8 +315,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/morgan-boulevard/index.html
+++ b/public/station/morgan-boulevard/index.html
@@ -317,7 +317,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/mt-vernon-sq/index.html
+++ b/public/station/mt-vernon-sq/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/mt-vernon-sq/index.html
+++ b/public/station/mt-vernon-sq/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/navy-yard-ballpark/index.html
+++ b/public/station/navy-yard-ballpark/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/navy-yard-ballpark/index.html
+++ b/public/station/navy-yard-ballpark/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/naylor-road/index.html
+++ b/public/station/naylor-road/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/naylor-road/index.html
+++ b/public/station/naylor-road/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/new-carrollton/index.html
+++ b/public/station/new-carrollton/index.html
@@ -324,7 +324,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/new-carrollton/index.html
+++ b/public/station/new-carrollton/index.html
@@ -305,7 +305,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -322,8 +322,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/noma/index.html
+++ b/public/station/noma/index.html
@@ -275,7 +275,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -290,8 +290,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/noma/index.html
+++ b/public/station/noma/index.html
@@ -292,7 +292,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/north-bethesda/index.html
+++ b/public/station/north-bethesda/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/north-bethesda/index.html
+++ b/public/station/north-bethesda/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/pentagon-city/index.html
+++ b/public/station/pentagon-city/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/pentagon-city/index.html
+++ b/public/station/pentagon-city/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/pentagon/index.html
+++ b/public/station/pentagon/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/pentagon/index.html
+++ b/public/station/pentagon/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/potomac-ave/index.html
+++ b/public/station/potomac-ave/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/potomac-ave/index.html
+++ b/public/station/potomac-ave/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/potomac-yard/index.html
+++ b/public/station/potomac-yard/index.html
@@ -384,7 +384,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/potomac-yard/index.html
+++ b/public/station/potomac-yard/index.html
@@ -357,7 +357,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -376,11 +376,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/reston-town-center/index.html
+++ b/public/station/reston-town-center/index.html
@@ -355,7 +355,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -374,11 +374,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/reston-town-center/index.html
+++ b/public/station/reston-town-center/index.html
@@ -382,7 +382,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/rhode-island-ave/index.html
+++ b/public/station/rhode-island-ave/index.html
@@ -341,7 +341,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -360,11 +360,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/rhode-island-ave/index.html
+++ b/public/station/rhode-island-ave/index.html
@@ -368,7 +368,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/rockville/index.html
+++ b/public/station/rockville/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/rockville/index.html
+++ b/public/station/rockville/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/rosslyn/index.html
+++ b/public/station/rosslyn/index.html
@@ -268,7 +268,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -283,8 +283,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/rosslyn/index.html
+++ b/public/station/rosslyn/index.html
@@ -285,7 +285,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/shady-grove/index.html
+++ b/public/station/shady-grove/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/shady-grove/index.html
+++ b/public/station/shady-grove/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/shaw-howard-u/index.html
+++ b/public/station/shaw-howard-u/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/shaw-howard-u/index.html
+++ b/public/station/shaw-howard-u/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/silver-spring/index.html
+++ b/public/station/silver-spring/index.html
@@ -342,7 +342,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -360,11 +360,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/silver-spring/index.html
+++ b/public/station/silver-spring/index.html
@@ -368,7 +368,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/smithsonian/index.html
+++ b/public/station/smithsonian/index.html
@@ -275,7 +275,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -290,8 +290,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/smithsonian/index.html
+++ b/public/station/smithsonian/index.html
@@ -292,7 +292,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/southern-ave/index.html
+++ b/public/station/southern-ave/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/southern-ave/index.html
+++ b/public/station/southern-ave/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/spring-hill/index.html
+++ b/public/station/spring-hill/index.html
@@ -207,15 +207,15 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from"><span class="fare-station-label">From</span><span class="fare-station-name" id="fare-from-name">Spring Hill</span></div>
             <div class="fare-arrow"><i class="ri-arrow-right-box-fill" aria-hidden="true"></i></div>
             <div class="fare-station fare-to"><span class="fare-station-label">To</span><select id="fare-destination" class="fare-select" aria-label="Select destination station"><option value="">Select destination...</option></select></div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/spring-hill/index.html
+++ b/public/station/spring-hill/index.html
@@ -216,7 +216,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/stadium-armory/index.html
+++ b/public/station/stadium-armory/index.html
@@ -290,7 +290,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/stadium-armory/index.html
+++ b/public/station/stadium-armory/index.html
@@ -273,7 +273,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -288,8 +288,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/suitland/index.html
+++ b/public/station/suitland/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/suitland/index.html
+++ b/public/station/suitland/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/takoma/index.html
+++ b/public/station/takoma/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/takoma/index.html
+++ b/public/station/takoma/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/tenleytown-au/index.html
+++ b/public/station/tenleytown-au/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/tenleytown-au/index.html
+++ b/public/station/tenleytown-au/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/twinbrook/index.html
+++ b/public/station/twinbrook/index.html
@@ -289,7 +289,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/twinbrook/index.html
+++ b/public/station/twinbrook/index.html
@@ -272,7 +272,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -287,8 +287,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/tysons/index.html
+++ b/public/station/tysons/index.html
@@ -271,7 +271,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -286,8 +286,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/tysons/index.html
+++ b/public/station/tysons/index.html
@@ -288,7 +288,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/u-street/index.html
+++ b/public/station/u-street/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/u-street/index.html
+++ b/public/station/u-street/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/union-station/index.html
+++ b/public/station/union-station/index.html
@@ -321,7 +321,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/union-station/index.html
+++ b/public/station/union-station/index.html
@@ -304,7 +304,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -319,8 +319,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/van-dorn-street/index.html
+++ b/public/station/van-dorn-street/index.html
@@ -298,7 +298,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -315,8 +315,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/van-dorn-street/index.html
+++ b/public/station/van-dorn-street/index.html
@@ -317,7 +317,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/van-ness-udc/index.html
+++ b/public/station/van-ness-udc/index.html
@@ -275,7 +275,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -290,8 +290,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/van-ness-udc/index.html
+++ b/public/station/van-ness-udc/index.html
@@ -292,7 +292,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/vienna/index.html
+++ b/public/station/vienna/index.html
@@ -268,7 +268,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -283,8 +283,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/vienna/index.html
+++ b/public/station/vienna/index.html
@@ -285,7 +285,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/virginia-square/index.html
+++ b/public/station/virginia-square/index.html
@@ -268,7 +268,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -283,8 +283,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/virginia-square/index.html
+++ b/public/station/virginia-square/index.html
@@ -285,7 +285,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/washington-dulles/index.html
+++ b/public/station/washington-dulles/index.html
@@ -385,7 +385,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/washington-dulles/index.html
+++ b/public/station/washington-dulles/index.html
@@ -358,7 +358,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -377,11 +377,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/waterfront/index.html
+++ b/public/station/waterfront/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/waterfront/index.html
+++ b/public/station/waterfront/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/west-falls-church/index.html
+++ b/public/station/west-falls-church/index.html
@@ -268,7 +268,7 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -283,8 +283,8 @@
             </div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/west-falls-church/index.html
+++ b/public/station/west-falls-church/index.html
@@ -285,7 +285,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/west-hyattsville/index.html
+++ b/public/station/west-hyattsville/index.html
@@ -363,7 +363,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/west-hyattsville/index.html
+++ b/public/station/west-hyattsville/index.html
@@ -337,7 +337,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -355,11 +355,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/wheaton/index.html
+++ b/public/station/wheaton/index.html
@@ -371,7 +371,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/station/wheaton/index.html
+++ b/public/station/wheaton/index.html
@@ -345,7 +345,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -363,11 +363,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/wiehle-reston-east/index.html
+++ b/public/station/wiehle-reston-east/index.html
@@ -207,15 +207,15 @@
       <section class="fare-card animate-in d4" id="fare-card">
         <div class="fare-header"><h2 class="fare-title">Fare Calculator</h2></div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from"><span class="fare-station-label">From</span><span class="fare-station-name" id="fare-from-name">Wiehle&#8211;Reston East</span></div>
             <div class="fare-arrow"><i class="ri-arrow-right-box-fill" aria-hidden="true"></i></div>
             <div class="fare-station fare-to"><span class="fare-station-label">To</span><select id="fare-destination" class="fare-select" aria-label="Select destination station"><option value="">Select destination...</option></select></div>
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
-            <div class="fare-result-row"><span class="fare-result-label">Peak</span><span class="fare-result-value" id="fare-peak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Off-Peak</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>

--- a/public/station/wiehle-reston-east/index.html
+++ b/public/station/wiehle-reston-east/index.html
@@ -216,7 +216,7 @@
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row"><span class="fare-result-label">Weekday</span><span class="fare-result-value" id="fare-peak">--</span></div>
             <div class="fare-result-row"><span class="fare-result-label">Late Night/Wknd</span><span class="fare-result-value" id="fare-offpeak">--</span></div>
-            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled</span><span class="fare-result-value" id="fare-senior">--</span></div>
+            <div class="fare-result-row"><span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span><span class="fare-result-value" id="fare-senior">--</span></div>
             <div class="fare-result-row fare-result-row--time"><span class="fare-result-label">Travel Time</span><span class="fare-result-value" id="fare-time">--</span></div>
           </div>
         </div>

--- a/public/station/woodley-park/index.html
+++ b/public/station/woodley-park/index.html
@@ -341,7 +341,7 @@
           <h2 class="fare-title">Fare Calculator</h2>
         </div>
         <div class="fare-body">
-          <p class="fare-description">Select a destination to see peak, off-peak, and reduced fares from this station.</p>
+          <p class="fare-description">Select a destination to see weekday, late night/weekend, and reduced fares from this station.</p>
           <div class="fare-route">
             <div class="fare-station fare-from">
               <span class="fare-station-label">From</span>
@@ -360,11 +360,11 @@
           </div>
           <div class="fare-results" id="fare-results" style="display:none;">
             <div class="fare-result-row">
-              <span class="fare-result-label">Peak</span>
+              <span class="fare-result-label">Weekday</span>
               <span class="fare-result-value" id="fare-peak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Off-Peak</span>
+              <span class="fare-result-label">Late Night/Wknd</span>
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">

--- a/public/station/woodley-park/index.html
+++ b/public/station/woodley-park/index.html
@@ -368,7 +368,7 @@
               <span class="fare-result-value" id="fare-offpeak">--</span>
             </div>
             <div class="fare-result-row">
-              <span class="fare-result-label">Senior/Disabled</span>
+              <span class="fare-result-label">Senior/Disabled &amp; Metro Lift</span>
               <span class="fare-result-value" id="fare-senior">--</span>
             </div>
             <div class="fare-result-row fare-result-row--time">

--- a/public/terms/index.html
+++ b/public/terms/index.html
@@ -118,7 +118,7 @@
       <!-- Section 2 -->
       <h2>2. No Affiliation with WMATA</h2>
       <p class="legal-emphasis">NEXTMETRO IS NOT AFFILIATED WITH, ENDORSED BY, SPONSORED BY, OR IN ANY WAY OFFICIALLY CONNECTED WITH THE WASHINGTON METROPOLITAN AREA TRANSIT AUTHORITY (WMATA).</p>
-      <p>&ldquo;Metro,&rdquo; &ldquo;Metrorail,&rdquo; &ldquo;Metrobus,&rdquo; &ldquo;MetroAccess,&rdquo; &ldquo;SmarTrip,&rdquo; and associated names, marks, logos, and designs are trademarks or registered trademarks of WMATA. NextMetro's use of WMATA data and references to Metro services does not imply any endorsement, sponsorship, or affiliation.</p>
+      <p>&ldquo;Metro,&rdquo; &ldquo;Metrorail,&rdquo; &ldquo;Metrobus,&rdquo; &ldquo;MetroAccess,&rdquo; &ldquo;SmarTrip&reg;,&rdquo; and associated names, marks, logos, and designs are trademarks or registered trademarks of WMATA. NextMetro's use of WMATA data and references to Metro services does not imply any endorsement, sponsorship, or affiliation.</p>
       <p>The official source for WMATA information is <a href="https://wmata.com" target="_blank" rel="noopener noreferrer">wmata.com</a>.</p>
 
       <!-- Section 3 -->


### PR DESCRIPTION
## Summary
This PR updates all fare-related content and logic to reflect WMATA's June 2023 elimination of peak/off-peak fare distinctions within weekdays. The new fare structure distinguishes between weekday fares (opening–9:30 PM) and late-night/weekend fares (after 9:30 PM and all day weekends/holidays).

## Key Changes

- **Fare detection logic**: Replaced `isPeakTime()` function with `isWeekdayFare()` that checks if a trip occurs on a weekday before 9:30 PM, eliminating the previous morning (5:00–9:30 AM) and evening (3:00–7:00 PM) peak windows
- **UI indicators**: Updated peak/off-peak status labels to display "Weekday Fares Active", "Weekend Fares Active", or "Late Night Fares Active" based on current time
- **Metadata and SEO**: Updated page titles, meta descriptions, and Open Graph/Twitter Card tags across fares page and hours page to reference "Weekday & Weekend Prices" instead of "Peak & Off-Peak Prices"
- **FAQ content**: Revised structured data (schema.org) to clarify the new fare structure with specific times and rates
- **Station pages**: Updated fare calculator descriptions on all 90+ station pages from "peak, off-peak, and reduced fares" to "weekday, late night/weekend, and reduced fares"
- **Mobile responsive table**: Added CSS for mobile-friendly fare table display with `data-label` attributes for column headers
- **Round-trip calculation**: Simplified round-trip fare estimation to use weekday fares when applicable instead of mixing peak and off-peak

## Implementation Details

- The `isPeakTime` function is maintained as an alias to `isWeekdayFare` for backward compatibility with existing API field names
- Fare rates remain unchanged ($2.25–$6.75 for weekday distance-based, $2.25–$2.50 for late night/weekend)
- Senior/disabled reduced fares updated to $1.10–$3.35 range in documentation
- Mobile CSS improvements include block-level table rendering with flexbox for better readability on small screens

https://claude.ai/code/session_014PWdkX1S42iZjnqLAcrkSa