### PR TITLE
Fix terminus label overlap on narrower viewports

### DIFF
--- a/public/css/line.css
+++ b/public/css/line.css
@@ -327,6 +327,32 @@ main[data-line] {
   white-space: nowrap;
 }
 
+@media (max-width: 860px) {
+  .line-termini-inner {
+    flex-direction: column;
+    align-items: center;
+    gap: var(--nm-space-sm);
+  }
+
+  .line-termini-station {
+    font-size: 0.875rem;
+    white-space: normal;
+    text-align: center;
+    justify-content: center;
+    flex-shrink: 1;
+  }
+
+  .line-termini-track {
+    width: 100%;
+    flex: 0 0 auto;
+  }
+
+  .line-termini-count {
+    white-space: normal;
+    text-align: center;
+  }
+}
+
 /* ---- Section Headings ---- */
 .line-section-heading {
   font-family: var(--nm-font);
@@ -965,10 +991,6 @@ main[data-line] {
 
   .line-info-value {
     text-align: left;
-  }
-
-  .line-termini-station {
-    font-size: 0.875rem;
   }
 
   .line-termini-dot {

--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -87,6 +87,7 @@
 @media (max-width: 768px) {
   .nm-nav__links {
     margin-right: 0;
+    border-left: none;
   }
 }
 


### PR DESCRIPTION
Long terminus names (e.g. Franconia-Springfield, Vienna/Fairfax-GMU)
combined with the stations-and-distance count could overflow their
container on Blue, Orange, and Silver line pages. Stack the terminus
layout vertically below 860px so names and the count wrap cleanly
instead of colliding.

https://claude.ai/code/session_01BFRL4VNyDCPUX5KgbecoV9